### PR TITLE
Add sc_l2_segment_aliases module

### DIFF
--- a/ansible_collections/serverscom/sc_api/README.md
+++ b/ansible_collections/serverscom/sc_api/README.md
@@ -65,4 +65,5 @@ List of modules
 * `sc_l2_segment_info` - information about L2 segment
 * `sc_l2_segments_info` - list of existing L2 segments
 * `sc_l2_segment` - Creation/delelition/membership modification for L2 segments
+* `sc_l2_segment_aliases` - Adding and removing IP addresses to/from L2 segments
 

--- a/ansible_collections/serverscom/sc_api/galaxy.yml
+++ b/ansible_collections/serverscom/sc_api/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: serverscom
 name: sc_api
-version: 0.0.5
+version: 0.0.6
 readme: README.md
 authors:
   - George Shuklin <george.shuklin@gmail.com>

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/modules.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/modules.py
@@ -1361,7 +1361,6 @@ class ScL2SegmentAliases():
                 raise ModuleError(f"Segment { self.name } is not found.")
         return existing_segment_id
 
-
     def wait_for(self, l2):
         start_time = time.time()
         if not self.wait:
@@ -1375,7 +1374,7 @@ class ScL2SegmentAliases():
                     f" Last status was {l2['status']}",
                     timeout=elapsed
                 )
-            l2  = self.api.get_l2_segment(l2['id'])
+            l2 = self.api.get_l2_segment(l2['id'])
 
     def prep_result(self, changed):
         aliases = list(self.api.list_l2_segment_networks(self.found_segment_id))
@@ -1410,9 +1409,10 @@ class ScL2SegmentAliases():
 
     @staticmethod
     def get_del_list(aliases_existing_ids, aliases_absent_ids):
-        return list(set(aliases_absent_ids)  & set(aliases_existing_ids))
+        return list(set(aliases_absent_ids) & set(aliases_existing_ids))
 
     def remove_aliases(self, to_remove_ids):
+        changed = False
         del_list = self.get_del_list(self.existing_aliases_id, to_remove_ids)
         if del_list:
             changed = True
@@ -1434,7 +1434,7 @@ class ScL2SegmentAliases():
         self.existing_aliases = list(self.api.list_l2_segment_networks(self.found_segment_id))
         self.existing_aliases_id = self.extract_ids(self.existing_aliases)
         if self.aliases_absent:
-            return self.remove_aliases()
+            return self.remove_aliases(self.aliases_absent)
         else:
             if self.count is None:
                 raise ModuleError('Count must not be None')

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/sc_api.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/sc_api.py
@@ -573,6 +573,19 @@ class ScApi():
             path=f"/l2_segments/{l2_segment_id}/networks"
         )
 
+    def put_l2_segment_networks(self, l2_segment_id, create, delete):
+        '''create: object: mask (int), distribution_method: must be "route"'''
+        body = {
+            "create": create,
+            "delete": delete
+        }
+        return self.api_helper.make_put_request(
+            path=f"/l2_segments/{l2_segment_id}/networks",
+            query_parameters=None,
+            body=body,
+            good_codes=[200, 202]
+        )
+
     def get_l2_segment(self, l2_segment_id):
         return self.api_helper.make_get_request(path=f"/l2_segments/{l2_segment_id}")
 

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment_aliases.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment_aliases.py
@@ -91,23 +91,30 @@ options:
 """
 
 RETURN = """
+id:
+    description:
+        - Id of the segment
+    returned: on success
+    type: list
+
 aliases:
     description:
         - List of aliases
     returned: on success
-    type: list
-    elements: complex
+    type: complex
     contains:
       id:
         description:
           - ID of alias
         type: str
       family:
+        type: str
         description:
           - Either ipv4 or ipv6
       cidr:
-        description
-          - IP address of the alias
+        type: str
+        description:
+          - IP address of the alias with /32 mask
 
 alias_count:
     description:
@@ -120,14 +127,14 @@ ipv4_list:
         - List of IPv4 addresses
     returned: on success
     type: list
-    elements: std
+    elements: str
 
 ipv6_list:
     description:
         - List of IPv6 addresses
     returned: on success
     type: list
-    elements: std
+    elements: str
 
 api_url:
     description: URL for the failed request

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment_aliases.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment_aliases.py
@@ -1,0 +1,231 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2020, Servers.com
+# GNU General Public License v3.0
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: sc_l2_segment_aliases
+version_added: "1.0.0"
+author: "George Shuklin (@amarao)"
+short_description: Managing L2 segement
+description: >
+    Create/delete L2 segment aliases.
+
+options:
+    endpoint:
+      type: str
+      default: https://api.servers.com/v1
+      description:
+        - Endpoint to use to connect to API.
+
+    token:
+      type: str
+      required: true
+      description:
+        - Token to use.
+        - You can create token for you account in https://portal.servers.com
+          in Profile -> Public API section.
+
+    name:
+      type: str
+      description:
+        - Name of the segment
+        - This module required to all segments to have unique names
+        - If two segments have the same name (even in different location groups
+          or having different type), this module fails
+        - Either I(name) or I(segment_id) is required for delete/update of
+          existing segment.
+        - I(name) is required if new segment need to be created
+
+    segment_id:
+      type: str
+      description:
+        - ID of the segment
+        - Either I(name) or I(segment_id) can be used
+
+    count:
+      type: int
+      description:
+        - Number of aliases assigned to L2 segment
+        - Either I(count) or I(aliases_absent) can be used
+        - Either I(count) or I(aliases_absent) must be specified
+        - Value 0 removes all aliases
+
+    aliases_absent:
+      type: list
+      elements: str
+      description:
+        - List of aliases (by IP or ID) to be absent for the segment
+        - Either I(count) or I(aliases_absent) can be used
+        - Either I(count) or I(aliases_absent) must be specified
+
+    wait:
+      type: int
+      default: 1200
+      description:
+        - Max wait time for operation to be finished.
+        - By default waiting for L2 segment to become active.
+        - C(0) disable waiting (fire-and-forget mode)
+
+    update_interval:
+      type: int
+      default: 30
+      description:
+        - Interval for polling for of L2 segment
+        - Each update consumes API quota.
+        - Ignored if I(wait)=C(0)
+"""
+
+RETURN = """
+aliases:
+    description:
+        - List of aliases
+    returned: on success
+    type: list
+    elements: complex
+    contains:
+      id:
+        description:
+          - ID of alias
+        type: str
+      family:
+        description:
+          - Either ipv4 or ipv6
+      cidr:
+        description
+          - IP address of the alias
+
+alias_count:
+    description:
+        - Number of aliases
+    returned: on success
+    type: int
+
+ipv4_list:
+    description:
+        - List of IPv4 addresses
+    returned: on success
+    type: list
+    elements: std
+
+ipv6_list:
+    description:
+        - List of IPv6 addresses
+    returned: on success
+    type: list
+    elements: std
+
+api_url:
+    description: URL for the failed request
+    returned: on failure
+    type: str
+
+status_code:
+    description: Status code for the request
+    returned: always
+    type: int
+"""
+
+EXAMPLES = """
+- name: Assign two aliases to a segment
+  serverscom.sc_api.sc_l2_segment_aliases:
+    token: '{{ lookup("env", "SC_TOKEN") }}'
+    name: L2 example
+    count: 2
+  register: l2
+
+- name: Report aliases
+  debug: var=l2.l2_segment.networks
+
+- name: Remove aliases from a segment by ID
+  serverscom.sc_api.sc_l2_segment:
+    token: '{{ lookup("env", "SC_TOKEN") }}'
+    segment_id: 0m592Zmn
+    aliases_absent:
+      - 7p6bE0p3
+
+- name: Remove aliases from a segment by value
+  serverscom.sc_api.sc_l2_segment:
+    token: '{{ lookup("env", "SC_TOKEN") }}'
+    segment_id: L2 example
+    aliases_absent:
+      - 203.0.113.41
+      - 203.0.113.42
+
+- name: Remove all aliases from a segment
+  serverscom.sc_api.sc_l2_segment:
+    token: '{{ lookup("env", "SC_TOKEN") }}'
+    segment_id: L2 example
+    count: 0
+"""  # noqa
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.serverscom.sc_api.plugins.module_utils.modules import (
+    DEFAULT_API_ENDPOINT,
+    SCBaseError,
+    ScL2SegmentAliases,
+)
+
+
+__metaclass__ = type
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            "token": {"type": "str", "no_log": True, "required": True},
+            "endpoint": {"default": DEFAULT_API_ENDPOINT},
+            "name": {},
+            "segment_id": {},
+            "count": {"type": "int"},
+            "aliases_absent": {
+                "type": "list",
+                "elements": "str",
+            },
+            "wait": {"type": "int", "default": 1200},
+            "update_interval": {"type": "int", "default": 30},
+        },
+        mutually_exclusive=[
+            ("name", "segment_id"),
+            ("count", "aliases_absent"),
+        ],
+        required_one_of=[
+            ("name", "segment_id"),
+            ("count", "aliases_absent"),
+        ],
+        supports_check_mode=True,
+    )
+    try:
+        sc_info = ScL2SegmentAliases(
+            endpoint=module.params["endpoint"],
+            token=module.params["token"],
+            name=module.params["name"],
+            segment_id=module.params["segment_id"],
+            count=module.params["count"],
+            aliases_absent=module.params["aliases_absent"],
+            wait=module.params["wait"],
+            update_interval=module.params["update_interval"],
+            checkmode=module.check_mode
+        )
+        module.exit_json(**sc_info.run())
+    except SCBaseError as e:
+        module.exit_json(**e.fail())
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
@@ -77,7 +77,7 @@
         that:
           - test4_res is changed
           - test4_res.ipv4_list|length == 1
-          - test4_res.aliases[0] == test4_res.aliases[1] # there are two aliases, we should kept the one we hadn't deleted
+          - test4_res.aliases[0] == test3_res.aliases[1] # there are two aliases, we should kept the one we hadn't deleted
           - test4_res.aliases_count == 1
 
     - name: Test5, remove non-existing alias
@@ -93,7 +93,7 @@
         that:
           - test5_res is not changed
           - test5_res.ipv4_list|length == 1
-          - test5_res.aliases == 1
+          - test5_res.aliases|length == 1
           - test5_res.aliases_count == 1
 
   always:

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
@@ -77,7 +77,7 @@
         that:
           - test4_res is changed
           - test4_res.ipv4_list|length == 1
-          - test4_res.aliases[0] == test3_res.aliases[1] # there are two aliases, we should kept the one we hadn't deleted
+          - test4_res.aliases[0] == test3_res.aliases[1]  # there are two aliases, we should kept the one we hadn't deleted
           - test4_res.aliases_count == 1
 
     - name: Test5, remove non-existing alias
@@ -86,7 +86,7 @@
         endpoint: "{{ sc_endpoint }}"
         name: integration-test
         aliases_absent:
-          - "{{ test3_res.aliases[0].id }}" # should have been removed at test4
+          - "{{ test3_res.aliases[0].id }}"  # should have been removed at test4
       register: test5_res
     - name: Test5 check results
       assert:

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
@@ -1,0 +1,109 @@
+---
+- name: Check if there are sc_token and sc_endpoint variables
+  no_log: true
+  fail:
+    msg: 'You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml'
+  when: not sc_endpoint or not sc_token
+
+- block:
+    - name: Test prep, create public segment
+      sc_l2_segment:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        state: present
+        type: public
+        members:
+          - id: A12bgw1N
+            mode: native
+          - id: 7p6bxgp3
+            mode: native
+      register: test5
+      tags: create
+
+    - name: Test1, remove aliases from segement without aliases
+      sc_l2_segment_aliases:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        count: 0
+      register: test1_res
+    - name: Test1 check results
+      assert:
+        that:
+          - test1_res is not changed
+
+    - name: Test2, add aliases in check mode
+      sc_l2_segment_aliases:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        count: 2
+      check_mode: true
+      register: test2_res
+    - name: Test2 check results
+      assert:
+        that:
+          - test2_res is changed
+
+    - name: Test3, add aliases for real
+      sc_l2_segment_aliases:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        count: 2
+      register: test3_res
+    - name: Test3 check results
+      assert:
+        that:
+          - test3_res is changed
+          - test3_res.ipv4_list|length == 2
+          - test3_res.aliases|length == 2
+          - test3_res.aliases_count == 2
+          - test3_res.id is defined
+          - test3_res.ipv6_list == []
+
+
+    - name: Test4, remove alias by ID
+      sc_l2_segment_aliases:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        aliases_absent:
+          - '{{ test3_res.aliases[0].id }}'
+
+      register: test4_res
+    - name: Test4 check results
+      assert:
+        that:
+          - test4_res is changed
+          - test4_res.ipv4_list|length == 1
+          - test4_res.aliases|length == 1
+          - test4_res.aliases_count == 1
+          - test4_res.aliases_ids == 1
+
+    - name: Test5, remove non-existing alias
+      sc_l2_segment_aliases:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        aliases_absent:
+          - '{{ test3_res.aliases[0].id }}'  # should have been removed at test4
+      register: test5_res
+    - name: Test5 check results
+      assert:
+        that:
+          - test4_res is not changed
+          - test4_res.ipv4_list|length == 1
+          - test4_res.aliases|length == 1
+          - test4_res.aliases_count == 1
+          - test4_res.aliases_ids == 1
+
+  always:
+    - name: Test cleanup, Delete public segment
+      sc_l2_segment:
+        token: '{{ sc_token }}'
+        endpoint: '{{ sc_endpoint }}'
+        name: integration-test
+        state: absent
+        type: public

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_l2_segment_aliases/tasks/main.yaml
@@ -2,14 +2,14 @@
 - name: Check if there are sc_token and sc_endpoint variables
   no_log: true
   fail:
-    msg: 'You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml'
+    msg: "You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml"
   when: not sc_endpoint or not sc_token
 
 - block:
     - name: Test prep, create public segment
       sc_l2_segment:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         state: present
         type: public
@@ -23,8 +23,8 @@
 
     - name: Test1, remove aliases from segement without aliases
       sc_l2_segment_aliases:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         count: 0
       register: test1_res
@@ -35,8 +35,8 @@
 
     - name: Test2, add aliases in check mode
       sc_l2_segment_aliases:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         count: 2
       check_mode: true
@@ -48,8 +48,8 @@
 
     - name: Test3, add aliases for real
       sc_l2_segment_aliases:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         count: 2
       register: test3_res
@@ -63,14 +63,13 @@
           - test3_res.id is defined
           - test3_res.ipv6_list == []
 
-
     - name: Test4, remove alias by ID
       sc_l2_segment_aliases:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         aliases_absent:
-          - '{{ test3_res.aliases[0].id }}'
+          - "{{ test3_res.aliases[0].id }}"
 
       register: test4_res
     - name: Test4 check results
@@ -78,32 +77,30 @@
         that:
           - test4_res is changed
           - test4_res.ipv4_list|length == 1
-          - test4_res.aliases|length == 1
+          - test4_res.aliases[0] == test4_res.aliases[1] # there are two aliases, we should kept the one we hadn't deleted
           - test4_res.aliases_count == 1
-          - test4_res.aliases_ids == 1
 
     - name: Test5, remove non-existing alias
       sc_l2_segment_aliases:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         aliases_absent:
-          - '{{ test3_res.aliases[0].id }}'  # should have been removed at test4
+          - "{{ test3_res.aliases[0].id }}" # should have been removed at test4
       register: test5_res
     - name: Test5 check results
       assert:
         that:
-          - test4_res is not changed
-          - test4_res.ipv4_list|length == 1
-          - test4_res.aliases|length == 1
-          - test4_res.aliases_count == 1
-          - test4_res.aliases_ids == 1
+          - test5_res is not changed
+          - test5_res.ipv4_list|length == 1
+          - test5_res.aliases == 1
+          - test5_res.aliases_count == 1
 
   always:
     - name: Test cleanup, Delete public segment
       sc_l2_segment:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         name: integration-test
         state: absent
         type: public


### PR DESCRIPTION
The module repeats features of API. There is some inconsistency around mask (there is mask, but only /32 is supported, there are IPv6 addresses in "get", but only IPv4 addresses are available for registration).
