### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,10 +1,10 @@
 ---
 name: Ansible collection
 
-'on':
+"on":
   push:
     paths-ignore:
-      - '.github/**'
+      - ".github/**"
 
 jobs:
   lint:
@@ -48,7 +48,7 @@ jobs:
         run: ansible-galaxy collection build
         working-directory: ansible_collections/serverscom/sc_api
 
-  integration_tests:
+  integration_tests_cloud:
     runs-on: ubuntu-20.04
     needs: quick_tests
     concurrency: API
@@ -68,27 +68,19 @@ jobs:
         run: |
           envsubst < integration_config.yml.template > ansible_collections/serverscom/sc_api/tests/integration/integration_config.yml
         env:
-          SC_TOKEN: '${{ secrets.SC_TOKEN }}'
+          SC_TOKEN: "${{ secrets.SC_TOKEN }}"
       - name: Integration tests
-        run:
-          ansible-test integration --requirements --python 3.8
-            sc_ssh_key
-            sc_baremetal_locations_info
-            sc_baremetal_servers_info
-            sc_dedicated_server_info
-            sc_cloud_computing_flavors_info
-            sc_cloud_computing_regions_info
-            sc_cloud_computing_images_info
-            sc_cloud_computing_openstack_credentials
-            sc_cloud_computing_instance
-            sc_cloud_computing_instance_info
-            sc_cloud_computing_instance_ptr
-            sc_cloud_computing_instances_info
-            sc_l2_segment
-            sc_l2_segment_aliases
-            sc_l2_segments_info
-            sc_dedicated_server_reinstall_quick
-            sc_dedicated_server_reinstall_long
+        run: ansible-test integration --requirements --python 3.8
+          sc_ssh_key
+          sc_cloud_computing_flavors_info
+          sc_cloud_computing_regions_info
+          sc_cloud_computing_images_info
+          sc_cloud_computing_openstack_credentials
+          sc_cloud_computing_instance
+          sc_cloud_computing_instance_info
+          sc_cloud_computing_instance_ptr
+          sc_cloud_computing_instances_info
+          sc_dedicated_server_reinstall_long
         # sc_cloud_computing_instance_state - ?
         # sc_cloud_computing_instance_reinstall  - broken and unfinished
 
@@ -100,9 +92,82 @@ jobs:
           sync
           sync
 
+  integration_tests_bm:
+    runs-on: ubuntu-20.04
+    needs: integration_tests_cloud
+    concurrency: API
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -r requirements.txt
+      - name: Configure integration tests
+        run: |
+          envsubst < integration_config.yml.template > ansible_collections/serverscom/sc_api/tests/integration/integration_config.yml
+        env:
+          SC_TOKEN: "${{ secrets.SC_TOKEN }}"
+      - name: Integration tests
+        run: ansible-test integration --requirements --python 3.8
+          sc_ssh_key
+          sc_baremetal_locations_info
+          sc_baremetal_servers_info
+          sc_dedicated_server_info
+          sc_dedicated_server_reinstall_quick
+          sc_dedicated_server_reinstall_long
+
+        working-directory: ansible_collections/serverscom/sc_api
+      - name: Cleanup secrets
+        if: always()
+        run: |
+          dd if=/dev/zero bs=4k count=4 of=ansible_collections/serverscom/sc_api/tests/integration/integration_config.yml
+          sync
+          sync
+
+  integration_tests_l2:
+    runs-on: ubuntu-20.04
+    needs: integration_tests_bm
+    concurrency: API
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          pip install -r requirements.txt
+      - name: Configure integration tests
+        run: |
+          envsubst < integration_config.yml.template > ansible_collections/serverscom/sc_api/tests/integration/integration_config.yml
+        env:
+          SC_TOKEN: "${{ secrets.SC_TOKEN }}"
+      - name: Integration tests
+        run: ansible-test integration --requirements --python 3.8
+          sc_l2_segment
+          sc_l2_segment_aliases
+          sc_l2_segments_info
+
+        working-directory: ansible_collections/serverscom/sc_api
+      - name: Cleanup secrets
+        if: always()
+        run: |
+          dd if=/dev/zero bs=4k count=4 of=ansible_collections/serverscom/sc_api/tests/integration/integration_config.yml
+          sync
+          sync
+
   build:
     runs-on: ubuntu-20.04
-    needs: integration_tests
+    needs: integration_tests_l2
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,7 +80,6 @@ jobs:
           sc_cloud_computing_instance_info
           sc_cloud_computing_instance_ptr
           sc_cloud_computing_instances_info
-          sc_dedicated_server_reinstall_long
         # sc_cloud_computing_instance_state - ?
         # sc_cloud_computing_instance_reinstall  - broken and unfinished
 

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment.py
@@ -195,7 +195,7 @@ options:
 
     wait:
       type: int
-      default: 1200
+      default: 1800
       description:
         - Max wait time for operation to be finished.
         - By default waiting for L2 segment to become active.
@@ -393,7 +393,7 @@ def main():
                 },
             },
             "location_group_id": {},
-            "wait": {"type": "int", "default": 1200},
+            "wait": {"type": "int", "default": 1800},
             "update_interval": {"type": "int", "default": 30},
         },
         mutually_exclusive=[

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment_aliases.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment_aliases.py
@@ -75,7 +75,7 @@ options:
 
     wait:
       type: int
-      default: 1200
+      default: 1800
       description:
         - Max wait time for operation to be finished.
         - By default waiting for L2 segment to become active.
@@ -204,7 +204,7 @@ def main():
                 "type": "list",
                 "elements": "str",
             },
-            "wait": {"type": "int", "default": 1200},
+            "wait": {"type": "int", "default": 1800},
             "update_interval": {"type": "int", "default": 30},
         },
         mutually_exclusive=[

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instance/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instance/tasks/main.yaml
@@ -2,13 +2,13 @@
 - name: Check if there are sc_token and sc_endpoint variables
   no_log: true
   fail:
-    msg: 'You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml'
+    msg: "You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml"
   when: not sc_endpoint or not sc_token
 
 - name: Test1 invalid token
   sc_cloud_computing_instance:
     token: invalid
-    endpoint: '{{ sc_endpoint }}'
+    endpoint: "{{ sc_endpoint }}"
     instance_id: noID
     state: absent
   register: test1
@@ -19,8 +19,8 @@
 
 - name: Test2, state=absent of absent instance by id
   sc_cloud_computing_instance:
-    token: '{{ sc_token }}'
-    endpoint: '{{ sc_endpoint }}'
+    token: "{{ sc_token }}"
+    endpoint: "{{ sc_endpoint }}"
     instance_id: dQKnqxAR
     state: absent
   register: test2
@@ -32,8 +32,8 @@
 
 - name: Test3, state=absent for absent instance by name
   sc_cloud_computing_instance:
-    token: '{{ sc_token }}'
-    endpoint: '{{ sc_endpoint }}'
+    token: "{{ sc_token }}"
+    endpoint: "{{ sc_endpoint }}"
     name: 603838e8-e844-11ea-a4e0-7f7652cefc07
     state: absent
   register: test3
@@ -45,8 +45,8 @@
 
 - name: Test4, state=absent for absent instance by name with wrong region
   sc_cloud_computing_instance:
-    token: '{{ sc_token }}'
-    endpoint: '{{ sc_endpoint }}'
+    token: "{{ sc_token }}"
+    endpoint: "{{ sc_endpoint }}"
     name: 603838e8-e844-11ea-a4e0-7f7652cefc08
     region_id: 4242424242
     state: absent
@@ -59,34 +59,37 @@
 
 - name: Test prep, get region id
   sc_cloud_computing_regions_info:
-    token: '{{ sc_token }}'
-    endpoint: '{{ sc_endpoint }}'
+    token: "{{ sc_token }}"
+    endpoint: "{{ sc_endpoint }}"
   register: regions
+  tags: always
 
 - name: Tests prep, Get image id
   sc_cloud_computing_images_info:
-    token: '{{ sc_token }}'
-    endpoint: '{{ sc_endpoint }}'
-    region_id: '{{ regions.regions[0].id }}'
+    token: "{{ sc_token }}"
+    endpoint: "{{ sc_endpoint }}"
+    region_id: "{{ regions.regions[0].id }}"
   register: img_info
+  tags: always
 
 - name: Tests prep, Get flavor id
   sc_cloud_computing_flavors_info:
-    token: '{{ sc_token }}'
-    endpoint: '{{ sc_endpoint }}'
-    region_id: '{{ regions.regions[0].id }}'
+    token: "{{ sc_token }}"
+    endpoint: "{{ sc_endpoint }}"
+    region_id: "{{ regions.regions[0].id }}"
   register: flavor_info
+  tags: always
 
 - name: Test5, create absent instance in check_mode
   block:
     - name: Test5, create instance in check mode
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: '{{ img_info.cloud_images[0].id }}'
+        image_id: "{{ img_info.cloud_images[0].id }}"
         name: ec354674-e844-11ea-ac53-83e1244f3049
         backup_copies: 0
         gpn: true
@@ -96,21 +99,21 @@
 
     - name: Test5, get list of instances
       sc_cloud_computing_instances_info:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
       register: test5_instances
 
     - name: Check test5
       assert:
         that:
           - test5 is changed
-          - '''ec354674-e844-11ea-ac53-83e1244f3049'' not in test5_instances|to_json'
+          - "'ec354674-e844-11ea-ac53-83e1244f3049' not in test5_instances|to_json"
 
   always:
     - name: Test5 Cleanup
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: ec354674-e844-11ea-ac53-83e1244f3049
         wait: 600
@@ -120,12 +123,12 @@
   block:
     - name: Test6, create instance with wait
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: '{{ img_info.cloud_images[0].id }}'
+        image_id: "{{ img_info.cloud_images[0].id }}"
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
         gpn: true
@@ -136,26 +139,26 @@
 
     - name: Test6, get list of instances
       sc_cloud_computing_instances_info:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
       register: test6_instances
 
     - name: Check test6
       assert:
         that:
           - test6 is changed
-          - '''52310c60-7446-482d-a30e-2bedeb515878'' in test6_instances|to_json'
+          - "'52310c60-7446-482d-a30e-2bedeb515878' in test6_instances|to_json"
           - test6.status == 'ACTIVE'
           - test6.name == '52310c60-7446-482d-a30e-2bedeb515878'
 
     - name: Test6, create the same instance second time
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: '{{ img_info.cloud_images[0].id }}'
+        image_id: "{{ img_info.cloud_images[0].id }}"
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
         gpn: true
@@ -166,12 +169,12 @@
 
     - name: Test6, create the same instance third time in check_mode
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: '{{ img_info.cloud_images[0].id }}'
+        image_id: "{{ img_info.cloud_images[0].id }}"
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
         gpn: true
@@ -194,24 +197,23 @@
   always:
     - name: Test6 Cleanup
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: 52310c60-7446-482d-a30e-2bedeb515878
         wait: 600
         update_interval: 5
 
-
 - name: Test7, state=present without wait, state=absent with conflict wait
   block:
     - name: Test7, create instance without wait
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: '{{ img_info.cloud_images[0].id }}'
+        image_id: "{{ img_info.cloud_images[0].id }}"
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
         backup_copies: 0
         gpn: false
@@ -221,8 +223,8 @@
 
     - name: Test7, get list of instances
       sc_cloud_computing_instances_info:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
       register: test7_instances
 
     - name: Check Test7
@@ -231,12 +233,12 @@
           - test7 is changed
           - test7.status != 'ACTIVE'
           - test7.name == 'c4edd55c-8a79-4181-b880-917b8ee5cdf2'
-          - '''c4edd55c-8a79-4181-b880-917b8ee5cdf2'' in test7_instances|to_json'
+          - "'c4edd55c-8a79-4181-b880-917b8ee5cdf2' in test7_instances|to_json"
 
     - name: Test7, try to delete non-active instance without retry_on_conflicts
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
         retry_on_conflicts: false
@@ -250,8 +252,8 @@
 
     - name: Test7, try to delete non-active instance in check_mode
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
       check_mode: true
@@ -259,20 +261,20 @@
 
     - name: Test7, get list of instances after check_mode delete
       sc_cloud_computing_instances_info:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
       register: test7_instances_check_mode_delete
 
     - name: Check Test7 after check_mode delete
       assert:
         that:
           - test7_delete_check_mode is changed
-          - '''c4edd55c-8a79-4181-b880-917b8ee5cdf2'' in test7_instances_check_mode_delete|to_json'
+          - "'c4edd55c-8a79-4181-b880-917b8ee5cdf2' in test7_instances_check_mode_delete|to_json"
 
     - name: Test7, try to delete instance
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
         wait: 600
@@ -281,21 +283,21 @@
 
     - name: Test7, get list of instances after delete
       sc_cloud_computing_instances_info:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
       register: test7_instances_after_delete
 
     - name: Check Test7, after delete
       assert:
         that:
           - test7_delete is changed
-          - '''c4edd55c-8a79-4181-b880-917b8ee5cdf2'' not in test7_instances_after_delete'
+          - "'c4edd55c-8a79-4181-b880-917b8ee5cdf2' not in test7_instances_after_delete"
 
   always:
     - name: Test7 Cleanup
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
         wait: 600
@@ -305,23 +307,23 @@
   block:
     - name: Test8, invalid flavor_name
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
         name: 15a0688b-44f6-41e2-971c-4e860c402373
-        region_id: '{{ regions.regions[0].id }}'
-        flavor_name: 'dont.exist'
-        image_id: '{{ img_info.cloud_images[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
+        flavor_name: "dont.exist"
+        image_id: "{{ img_info.cloud_images[0].id }}"
       register: test8_flavor
       failed_when: false
 
     - name: Test8, invalid image_regexp
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
         name: 15a0688b-44f6-41e2-971c-4e860c402373
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_regexp: a.+dont.exist
       register: test8_image
@@ -330,14 +332,14 @@
     - name: Check test 8
       assert:
         that:
-          - '''Unable to find flavor by name dont.exist'' in test8_flavor.msg'
-          - '''Unable to find image by regexp a.+dont.exist'' in test8_image.msg'
+          - "'Unable to find flavor by name dont.exist' in test8_flavor.msg"
+          - "'Unable to find image by regexp a.+dont.exist' in test8_image.msg"
 
   always:
     - name: Test8, cleanup
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: 15a0688b-44f6-41e2-971c-4e860c402373
         wait: 600
@@ -346,19 +348,19 @@
   block:
     - name: Test9 create instanace with image by regexp and flavor by name
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
         name: 8d2779e6-eb72-11ea-970f-733ca983e4ca
-        region_id: '{{ regions.regions[0].id }}'
-        flavor_name: 'SSD.30'
-        image_regexp: 'Ubuntu.+'
+        region_id: "{{ regions.regions[0].id }}"
+        flavor_name: "SSD.30"
+        image_regexp: "Ubuntu.+"
       register: test9_create
     - name: Test9, delete instance by id
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
-        instance_id: '{{ test9_create.id }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
+        instance_id: "{{ test9_create.id }}"
         wait: 600
         state: absent
       register: test9_delete
@@ -374,32 +376,33 @@
   always:
     - name: Test9, cleanup
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: 8d2779e6-eb72-11ea-970f-733ca983e4ca
 
 - name: Test10, use of GP only with userdata
+  tags: [test10]
   block:
     - name: Test10 preparation, register a new key
       sc_ssh_key:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         public_key: '{{ lookup("file", "key1.pub") }}'
         name: 95f41cea-00fc-11ed-bfa8-33691f518c37
         state: present
       register: test10_key
     - name: Test10 create instanace with GP only and custom userdata
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: present
         name: d1b69136-00ed-11ed-a8dc-dbb69a235481
-        region_id: '{{ regions.regions[0].id }}'
+        region_id: "{{ regions.regions[0].id }}"
         gpn: true
         ipv4: false
-        flavor_name: 'SSD.30'
-        image_regexp: 'Ubuntu.+'
+        flavor_name: "SSD.30"
+        image_regexp: "Ubuntu.+"
         ssh_key_name: 95f41cea-00fc-11ed-bfa8-33691f518c37
         user_data: |
           #cloud-config
@@ -426,13 +429,13 @@
   always:
     - name: Test10, cleanup
       sc_cloud_computing_instance:
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent
         name: d1b69136-00ed-11ed-a8dc-dbb69a235481
     - name: clean ssh key
       sc_ssh_key:
         name: 95f41cea-00fc-11ed-bfa8-33691f518c37
-        token: '{{ sc_token }}'
-        endpoint: '{{ sc_endpoint }}'
+        token: "{{ sc_token }}"
+        endpoint: "{{ sc_endpoint }}"
         state: absent

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instance/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instance/tasks/main.yaml
@@ -85,7 +85,7 @@
         endpoint: '{{ sc_endpoint }}'
         state: present
         region_id: '{{ regions.regions[0].id }}'
-        flavor_id: '{{ flavor_info.cloud_flavors[0].id }}'
+        flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_id: '{{ img_info.cloud_images[0].id }}'
         name: ec354674-e844-11ea-ac53-83e1244f3049
         backup_copies: 0
@@ -124,7 +124,7 @@
         endpoint: '{{ sc_endpoint }}'
         state: present
         region_id: '{{ regions.regions[0].id }}'
-        flavor_id: '{{ flavor_info.cloud_flavors[0].id }}'
+        flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_id: '{{ img_info.cloud_images[0].id }}'
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
@@ -154,7 +154,7 @@
         endpoint: '{{ sc_endpoint }}'
         state: present
         region_id: '{{ regions.regions[0].id }}'
-        flavor_id: '{{ flavor_info.cloud_flavors[0].id }}'
+        flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_id: '{{ img_info.cloud_images[0].id }}'
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
@@ -170,7 +170,7 @@
         endpoint: '{{ sc_endpoint }}'
         state: present
         region_id: '{{ regions.regions[0].id }}'
-        flavor_id: '{{ flavor_info.cloud_flavors[0].id }}'
+        flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_id: '{{ img_info.cloud_images[0].id }}'
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
@@ -210,7 +210,7 @@
         endpoint: '{{ sc_endpoint }}'
         state: present
         region_id: '{{ regions.regions[0].id }}'
-        flavor_id: '{{ flavor_info.cloud_flavors[0].id }}'
+        flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_id: '{{ img_info.cloud_images[0].id }}'
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
         backup_copies: 0
@@ -322,7 +322,7 @@
         state: present
         name: 15a0688b-44f6-41e2-971c-4e860c402373
         region_id: '{{ regions.regions[0].id }}'
-        flavor_id: '{{ flavor_info.cloud_flavors[0].id }}'
+        flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
         image_regexp: a.+dont.exist
       register: test8_image
       failed_when: false

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_dedicated_server_reinstall_long/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_dedicated_server_reinstall_long/tasks/main.yaml
@@ -27,7 +27,7 @@
       - test1.id == existing_server1_id
       - test1.power_status == "powered_on"
 
-- name: Test1, wait until installtion is done
+- name: Test1, wait until installation is done
   sc_dedicated_server_info:
     token: '{{ sc_token }}'
     endpoint: '{{ sc_endpoint }}'
@@ -77,7 +77,7 @@
       - test3.ready
       - test3.title == "raid1test"
 
-- name: wait until installtion is done 2
+- name: wait until installation is done 2
   sc_dedicated_server_info:
     token: '{{ sc_token }}'
     endpoint: '{{ sc_endpoint }}'


### PR DESCRIPTION
1. Split integration tests into three stages
2. Bump timeout value for L2 segment operations to avoid fails in cases of switch configuration queue congestion.
3. Use the smallest flavor for VMs (sort by disk size).
4. Typos in test names