### PR TITLE
Updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,5 @@
 ---
-name: Ansible collection
+name: Test and build
 
 "on":
   push:
@@ -80,7 +80,7 @@ jobs:
           sc_cloud_computing_instance_info
           sc_cloud_computing_instance_ptr
           sc_cloud_computing_instances_info
-        # sc_cloud_computing_instance_state - ?
+          sc_cloud_computing_instance_state
         # sc_cloud_computing_instance_reinstall  - broken and unfinished
 
         working-directory: ansible_collections/serverscom/sc_api

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_l2_segment.py
@@ -88,7 +88,7 @@ options:
         - List of servers and mode of connection (native or trunk)
         - (Either I(members) or I(members_present) or I(members_absent)
           required if I(state)=C(present)
-        - L2 segment should contains at least two members
+        - L2 segment should contains at least one member
         - Server can be member of only one L2 segment in I(mode)=C(native)
         - Server can participate in multiple L2 segments in I(mode)=C(trunk)
         - Server can be present in a given segment only once (e.g. it's impossible
@@ -128,7 +128,7 @@ options:
           possible mode change (this option only assure that servers are added)
         - (Either I(members) or I(members_present) or I(members_absent)
           required if I(state)=C(present)
-        - L2 segment should contains at least two members
+        - L2 segment should contains at least one member
         - Server can be member of only one L2 segment in I(mode)=C(native)
         - Server can participate in multiple L2 segments in I(mode)=C(trunk)
         - Server can be present in a given segment only once (e.g. it's impossible
@@ -414,8 +414,6 @@ def main():
             module.fail_json(
                 "state=present required either members, or members_present, or members_absent"
             )
-        if module.params["members"] and len(module.params["members"]) < 2:
-            module.fail_json("members argument must contain at least two servers")
     try:
         sc_info = ScL2Segment(
             endpoint=module.params["endpoint"],

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instance_state/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instance_state/tasks/main.yaml
@@ -173,8 +173,6 @@
         instance_name: 4839550e-edf5-11ea-8df4-4f25b3878e42
       register: test7_result
 
-    - debug: var=[test7,test7_result]
-
     - name: Check Test7
       assert:
         that:
@@ -295,7 +293,6 @@
         wait: 0
       register: test13
 
-    - debug: var=[test13]
     - name: Check Test13
       assert:
         that:
@@ -313,18 +310,21 @@
       delay: 10
       retries: 60
 
-    - name: Test14, rescue in short timeout
+    - name: Test14, rescue
       sc_cloud_computing_instance_state:
         token: '{{ sc_token }}'
         endpoint: '{{ sc_endpoint }}'
         name: 4839550e-edf5-11ea-8df4-4f25b3878e42
         state: rescue
-        wait: 1
-        update_interval: 1
+        wait: 600
+        update_interval: 10
       register: test14
-      failed_when: false
 
     - debug: var=test14
+    - name: Tesat14, check result
+      assert:
+        that:
+          - test14.status == 'RESCUE'
 
   always:
     - name: Testsuite cleanup


### PR DESCRIPTION
1. reduce limit for server count in L2 (per updates in API)
2. Add tests for `sc_cloud_computing_instance_state` module in CI
3. Fix those tests to support updated cloud code in API.
4. 