### PR TITLE
Fix gpn parameter on instance creation

### DIFF
--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/modules.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/modules.py
@@ -519,7 +519,7 @@ class ScCloudComputingInstanceCreate:
             name=self.name,
             flavor_id=self.flavor_id,
             image_id=self.image_id,
-            gpn_enabled=self.image_id,
+            gpn_enabled=self.gpn_enabled,
             ipv4_enabled=self.ipv4_enabled,
             ipv6_enabled=self.ipv6_enabled,
             ssh_key_fingerprint=self.ssh_key_fingerprint,

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_cloud_computing_instance.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_cloud_computing_instance.py
@@ -330,7 +330,7 @@ public_ipv4_address:
 public_ipv6_address:
   type: str
   description:
-    - IPv5 address for instance.
+    - IPv6 address for instance.
     - May be missing if no IPv6 address was ordered or public inteface
      was detached via Openstack API.
   returned: on success


### PR DESCRIPTION
Fixed `gpn_enabled` parameter on instance creation. Also upgraded IPv5 to IPv6 in description.