### PR TITLE
Fix 404 error in cloud instance delete

### DIFF
--- a/ansible_collections/serverscom/sc_api/galaxy.yml
+++ b/ansible_collections/serverscom/sc_api/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: serverscom
 name: sc_api
-version: 0.0.8
+version: 0.1.0
 readme: README.md
 authors:
   - George Shuklin <george.shuklin@gmail.com>

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/modules.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/modules.py
@@ -629,6 +629,10 @@ class ScCloudComputingInstanceDelete:
                     time.sleep(self.update_interval)
                 else:
                     raise
+            except APIError404:
+                # We expected to delete instance and it's gone
+                # == happy end
+                pass
             instance = instance = self.api.toolbox.find_instance(
                 self.instance_id, self.name, self.region_id, must=False
             )


### PR DESCRIPTION
Example of error:

fatal: [testhost]: FAILED! => {"api_url": "https://api.servers.com/v1/cloud_computing/instances/....", "changed": false, "msg": "404 Not Found.", "status_code": 404}
