### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/action_lint.yaml
+++ b/.github/workflows/action_lint.yaml
@@ -9,7 +9,7 @@ name: Lint workflows
 jobs:
   workflow-linting:
     name: Workflow Linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: rhysd/actionlint:1.6.15
       options: --user=0 --entrypoint=/bin/sh

--- a/.github/workflows/action_lint.yaml
+++ b/.github/workflows/action_lint.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Workflow Linting
     runs-on: ubuntu-24.04
     container:
-      image: rhysd/actionlint:1.6.15
+      image: rhysd/actionlint:1.7.7
       options: --user=0 --entrypoint=/bin/sh
     steps:
       - name: checkout

--- a/.github/workflows/action_lint.yaml
+++ b/.github/workflows/action_lint.yaml
@@ -15,6 +15,6 @@ jobs:
       options: --user=0 --entrypoint=/bin/sh
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: actionlint
         run: /usr/local/bin/actionlint .github/workflows/*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install yamllint
         run: sudo apt install yamllint
       - name: Lint
@@ -26,9 +26,9 @@ jobs:
           - "3.11"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python_version }}
       - name: Install dependencies
@@ -51,9 +51,9 @@ jobs:
     concurrency: API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -93,9 +93,9 @@ jobs:
     concurrency: API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -130,9 +130,9 @@ jobs:
     concurrency: API
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -165,9 +165,9 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -194,7 +194,7 @@ jobs:
         working-directory: ansible_collections/serverscom/sc_api
       - name: Save artifact
         if: ${{ endsWith(github.ref, steps.version.outputs.version) }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sc_api
           path: ansible_collections/serverscom/sc_api/serverscom-sc_api-${{ steps.version.outputs.version }}.tar.gz
@@ -205,7 +205,7 @@ jobs:
     if: ${{ endsWith(github.ref, needs.build.outputs.version) }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: sc_api
       - name: Debug output

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -184,7 +184,7 @@ jobs:
         id: version
         run: |
           version=$(grep ^version galaxy.yml|awk '{print $2}')
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
         working-directory: ansible_collections/serverscom/sc_api
       - name: Print artifact info
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ name: Test and build
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
         run: yamllint .
 
   quick_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python_version:
@@ -46,7 +46,7 @@ jobs:
         working-directory: ansible_collections/serverscom/sc_api
 
   integration_tests_cloud:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: quick_tests
     concurrency: API
     steps:
@@ -88,7 +88,7 @@ jobs:
           sync
 
   integration_tests_bm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: integration_tests_cloud
     concurrency: API
     steps:
@@ -125,7 +125,7 @@ jobs:
           sync
 
   integration_tests_l2:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: integration_tests_bm
     concurrency: API
     steps:
@@ -159,7 +159,7 @@ jobs:
           sync
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: integration_tests_l2
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -200,7 +200,7 @@ jobs:
           path: ansible_collections/serverscom/sc_api/serverscom-sc_api-${{ steps.version.outputs.version }}.tar.gz
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: build
     if: ${{ endsWith(github.ref, needs.build.outputs.version) }}
     steps:

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instances_info/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instances_info/tasks/main.yaml
@@ -33,7 +33,7 @@
   sc_cloud_computing_instances_info:
     token: '{{ sc_token }}'
     endpoint: '{{ sc_endpoint }}'
-    region_id: 1
+    region_id: 2
   register: test3
 
 - name: Check Test3

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instances_info/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_cloud_computing_instances_info/tasks/main.yaml
@@ -42,7 +42,7 @@
       - test3 is not changed
       - test3.cloud_instances|length > 0
       - test3.cloud_instances[0].id
-      - test3.cloud_instances[0].region_id == 1
+      - test3.cloud_instances[0].region_id == 2
       - test3.cloud_instances[0].region_code
       - test3.cloud_instances[0].flavor_id
       - test3.cloud_instances[0].flavor_name


### PR DESCRIPTION
- Ubuntu 20.04 is no longer supported in GH actions, switch to Ubuntu 24.04
- Update actionlint (old version does not support ubuntu 24-04)
- Update deprecations, stated by actionlint
- Switch 'busy' region ID (for 'get') from 1 to 2 (LUX).