### PR TITLE
Add 'sc_baremetal_os_list' module

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,6 +112,7 @@ jobs:
           sc_ssh_key
           sc_baremetal_locations_info
           sc_baremetal_servers_info
+          sc_baremetal_os_list
           sc_dedicated_server_info
           sc_dedicated_server_reinstall_quick
           sc_dedicated_server_reinstall_long

--- a/ansible_collections/serverscom/sc_api/README.md
+++ b/ansible_collections/serverscom/sc_api/README.md
@@ -48,6 +48,7 @@ List of modules
 * `sc_baremetal_locations_info` - List of available baremetal locations
 * `sc_cloud_computing_regions_info`- List of cloud computing regions
 * `sc_baremetal_servers_info` - List of baremetal servers
+* `sc_baremetal_os_list` - List of the available OS options for the specific region and server model or server ID
 * `sc_dedicated_server_info` - Information about one dedicated server
 * `sc_dedicated_server_reinstall` - Reinstallation of servers
 * `sc_ssh_key` - SSH key management

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/sc_api.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/sc_api.py
@@ -321,6 +321,9 @@ class ScApi:
             path=f"/hosts/dedicated_servers/{server_id}"
         )
 
+    def get_sbm_servers(self, server_id):
+        return self.api_helper.make_get_request(path=f"/hosts/sbm_servers/{server_id}")
+
     def list_hosts(self, type=None, search_pattern=None, label_selector=None):
         query = {}
         if type:
@@ -841,4 +844,36 @@ class ScApi:
             body=None,
             query_parameters=None,
             good_codes=[202],
+        )
+
+    def list_server_models(self, location_id, search_pattern=None):
+        if search_pattern:
+            query = {"search_pattern": search_pattern}
+        else:
+            query = None
+        return self.api_helper.make_multipage_request(
+            path=f"/locations/{location_id}/order_options/server_models",
+            query_parameters=query,
+        )
+
+    def list_sbm_flavor_models(self, location_id, search_pattern=None):
+        if search_pattern:
+            query = {"search_pattern": search_pattern}
+        else:
+            query = None
+        return self.api_helper.make_multipage_request(
+            path=f"/locations/{location_id}/order_options/sbm_flavor_models",
+            query_parameters=query,
+        )
+
+    def list_os_images_by_model_id(self, location_id, model_id):
+        return self.api_helper.make_multipage_request(
+            path=f"/locations/{location_id}/order_options/server_models/{model_id}/operating_systems",
+            query_parameters=None,
+        )
+
+    def list_os_images_by_sbm_flavor_id(self, location_id, sbm_flavor_id):
+        return self.api_helper.make_multipage_request(
+            path=f"/locations/{location_id}/order_options/sbm_flavor_models/{sbm_flavor_id}/operating_systems",
+            query_parameters=None,
         )

--- a/ansible_collections/serverscom/sc_api/plugins/modules/sc_baremetal_os_list.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/sc_baremetal_os_list.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2025, Servers.com
+# GNU General Public License v3.0
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: sc_baremetal_os_list
+version_added: "1.0.0"
+author: "Volodymyr Rudniev (@koef)"
+short_description: Return available operating system options.
+description: >
+    Return list of OS images for bare metal servers in a specified location.
+
+options:
+    endpoint:
+      type: str
+      default: https://api.servers.com/v1
+      description:
+        - API endpoint.
+    token:
+      type: str
+      required: true
+      no_log: true
+      description:
+        - API token.
+    server_id:
+      type: str
+      description:
+        - A unique identifier of the bare metal server.
+        - If specified the module will return OS options for the specified server.
+        - If set the parameters I(location_id), I(location_code), I(server_model_id), and I(server_model_name) will be ignored.
+    location_id:
+      type: str
+      description:
+        - Location identifier.
+    location_code:
+      type: str
+      description:
+        - Human-readable location slug (mutually exclusive with I(location_id)).
+    server_model_id:
+      type: str
+      description:
+        - Server model identifier (mutually exclusive with I(server_model_name)).
+    server_model_name:
+      type: str
+      description:
+        - Server model name (mutually exclusive with I(server_model_id)).
+    sbm_flavor_model_id:
+      type: str
+      description:
+        - A unique identifier of an SBM flavor.
+        - If set the module will return OS options for the specified SBM model.
+    sbm_flavor_model_name:
+      type: str
+      description:
+        - Human-readable name of an SBM flavor (mutually exclusive with I(sbm_flavor_model_id)).
+        - If set the module will return OS options for the specified SBM model.
+    os_name_regex:
+      type: str
+      description:
+        - A regular expression to filter OS options by name.
+        - If specified, the module will return only OS options that match the provided regex.
+"""
+
+RETURN = """
+os_list:
+  type: list
+  elements: dict
+  returned: on success
+  description:
+    - List of operating system options.
+  contains:
+    id:
+      type: str
+      description: A unique identifier of an operating system.
+    full_name:
+      type: str
+      description: This parameter contains a name, version, and architecture of an operating system.
+    name:
+      type: str
+      description: A human-readable name of an operating system.
+    version:
+      type: str
+      description: A version of an operating system.
+    arch:
+      type: str
+      description: Architecture of an operating system.
+    filesystems:
+      type: list
+      description: This parameter contains a list of available file systems for an operating system.
+
+api_url:
+  type: str
+  returned: on failure
+  description:
+    - Failed request URL.
+status_code:
+  type: int
+  returned: always
+  description:
+    - HTTP status code.
+"""
+
+EXAMPLES = """
+    - name: List OS options by location_id and server_model_id
+      sc_baremetal_os_list:
+        token: "{{ api_token }}"
+        location_id: "34"
+        server_model_id: "12345"
+      register: result
+
+    - name: List OS options by location_code and server_model_name
+      sc_baremetal_os_list:
+        token: "{{ api_token }}"
+        location_code: "ams1"
+        server_model_name: "R430"
+      register: result
+
+    - name: List OS options by location and SBM model
+      sc_baremetal_os_list:
+        token: "{{ api_token }}"
+        location_id: "32"
+        sbm_flavor_model_id: "1287"
+      register: result
+
+    - debug:
+        var: result.os_list
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.serverscom.sc_api.plugins.module_utils.modules import (
+    DEFAULT_API_ENDPOINT,
+    SCBaseError,
+    ScDedicatedOSList,
+)
+
+
+def main():
+    argument_spec = dict(
+        token=dict(type="str", required=True, no_log=True),
+        endpoint=dict(type="str", default=DEFAULT_API_ENDPOINT),
+        server_id=dict(type="str"),
+        location_id=dict(type="str"),
+        location_code=dict(type="str"),
+        server_model_id=dict(type="str"),
+        server_model_name=dict(type="str"),
+        sbm_flavor_model_id=dict(type="str"),
+        sbm_flavor_model_name=dict(type="str"),
+        os_name_regex=dict(type="str"),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[
+            ["location_id", "location_code", "server_id"],
+            [
+                "server_model_id",
+                "server_model_name",
+                "sbm_model_id",
+                "sbm_flavor_model_name",
+                "sbm_flavor_model_id",
+                "server_id",
+            ],
+        ],
+        mutually_exclusive=[
+            ["location_id", "location_code", "server_id"],
+            ["server_model_id", "server_model_name"],
+            ["sbm_flavor_model_id", "sbm_flavor_model_name"],
+        ],
+    )
+    try:
+        sc_os = ScDedicatedOSList(
+            endpoint=module.params["endpoint"],
+            token=module.params["token"],
+            server_id=module.params.get("server_id"),
+            location_id=module.params.get("location_id"),
+            location_code=module.params.get("location_code"),
+            server_model_id=module.params.get("server_model_id"),
+            server_model_name=module.params.get("server_model_name"),
+            sbm_flavor_model_id=module.params.get("sbm_flavor_model_id"),
+            sbm_flavor_model_name=module.params.get("sbm_flavor_model_name"),
+            os_name_regex=module.params.get("os_name_regex"),
+        )
+        module.exit_json(**sc_os.run())
+    except SCBaseError as e:
+        module.fail_json(**e.fail())
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
@@ -74,7 +74,7 @@
       - test5.os_list | length > 0
       - test5.os_list[0].name
 
-- name: Test3, No any OS options found
+- name: Test6, No any OS options found
   sc_baremetal_os_list:
     token: "{{ sc_token }}"
     server_id: "{{ existing_server1_id }}"

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
@@ -1,0 +1,75 @@
+---
+- name: Check if there are sc_token and sc_endpoint variables
+  no_log: true
+  fail:
+    msg: "You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml"
+  when: not sc_endpoint or not sc_token
+
+- name: Test invalid token
+  sc_baremetal_os_list:
+    token: invalid
+    server_id: "{{ existing_server1_id}}"
+  register: test1
+  failed_when:
+    - test1 is success
+    - test1.status_code != 401
+
+- name: Test2, Get OS list for a specific server
+  sc_baremetal_os_list:
+    token: "{{ sc_token }}"
+    server_id: "{{ existing_server1_id}}"
+  register: test2
+
+- name: Check Test2
+  assert:
+    that:
+      - test2 is not changed
+      - test2.os_list | length > 0
+      - test2.os_list[0].name
+      - test2.os_list[0].full_name
+      - test2.os_list[0].version
+      - test2.os_list[0].arch
+      - test2.os_list[0].id
+      - test2.os_list[0].filesystems | length > 0
+
+- name: Test3, Get OS list by name regex
+  sc_baremetal_os_list:
+    token: "{{ sc_token }}"
+    server_id: "{{ existing_server1_id }}"
+    os_name_regex: "^Ubuntu 24.04-server x86_64$"
+  register: test3
+
+- name: Check Test3
+  assert:
+    that:
+      - test3 is not changed
+      - test3.os_list | length == 1
+      - test3.os_list[0].name
+
+- name: Test4, Get OS list with location_id and server_model_id
+  sc_baremetal_os_list:
+    token: "{{ sc_token }}"
+    location_id: 34
+    server_model_id: 11940
+  register: test4
+
+- name: Check Test4
+  assert:
+    that:
+      - test4 is not changed
+      - test4.os_list | length > 0
+      - test4.os_list[0].name
+
+- name: Test5, Get OS list with location_code and server_model_name
+  sc_baremetal_os_list:
+    token: "{{ sc_token }}"
+    location_code: "ams1"
+    server_model_name: "Dell R730xd / 2xIntel Xeon E5-2680 v3 / 32 GB RAM / 4x600 GB SAS"
+  register: test5
+
+- name: Check Test5
+  assert:
+    that:
+      - test5 is not changed
+      - test5.os_list | length > 0
+      - test5.os_list[0].name

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
@@ -8,7 +8,7 @@
 - name: Test invalid token
   sc_baremetal_os_list:
     token: invalid
-    server_id: "{{ existing_server1_id}}"
+    server_id: "{{ existing_server1_id }}"
   register: test1
   failed_when:
     - test1 is success
@@ -17,7 +17,7 @@
 - name: Test2, Get OS list for a specific server
   sc_baremetal_os_list:
     token: "{{ sc_token }}"
-    server_id: "{{ existing_server1_id}}"
+    server_id: "{{ existing_server1_id }}"
   register: test2
 
 - name: Check Test2
@@ -73,3 +73,18 @@
       - test5 is not changed
       - test5.os_list | length > 0
       - test5.os_list[0].name
+
+- name: Test3, No any OS options found
+  sc_baremetal_os_list:
+    token: "{{ sc_token }}"
+    server_id: "{{ existing_server1_id }}"
+    os_name_regex: "^Ubuntu 24.04-server arm64$"
+  register: test6
+  failed_when:
+    - test6 is success
+
+- name: Check Test6
+  assert:
+    that:
+      - test6 is not changed
+      - test6.msg == "No operating systems found matching the criteria"

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_baremetal_os_list/tasks/main.yaml
@@ -74,7 +74,7 @@
       - test5.os_list | length > 0
       - test5.os_list[0].name
 
-- name: Test6, No any OS options found
+- name: Test6, None OS options found
   sc_baremetal_os_list:
     token: "{{ sc_token }}"
     server_id: "{{ existing_server1_id }}"


### PR DESCRIPTION
A new module `sc_baremetal_os_list` has been added. It allows fetching operating system options for:
- location + server model  
- location + SBM server model flavor  
- a specific server

Location, server model, and SBM server model flavor can be specified using either an ID or a name.

The resulting OS list can be filtered using the specified regular expression.