### PR TITLE
Add dedicated_server_ipxe module with auto-switch iPXE mode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ansible_collections/serverscom/sc_api/tests/integration/inventory
 ansible_collections/serverscom/sc_api/*.tar.gz
 output*
 .secrets/
+.claude/

--- a/ansible_collections/serverscom/sc_api/README.md
+++ b/ansible_collections/serverscom/sc_api/README.md
@@ -70,6 +70,7 @@ List of modules
 * `dedicated_server_info` - Information about one dedicated server
 * `dedicated_server_reinstall` - Reinstallation of dedicated servers
 * `dedicated_server_power` - Power management for dedicated baremetal servers
+* `dedicated_server_ipxe` - Managing the iPXE feature for dedicated baremetal servers
 
 **Cloud Computing**
 

--- a/ansible_collections/serverscom/sc_api/galaxy.yml
+++ b/ansible_collections/serverscom/sc_api/galaxy.yml
@@ -1,12 +1,13 @@
 ---
 namespace: serverscom
 name: sc_api
-version: 1.1.0
+version: 1.1.1
 readme: README.md
 authors:
   - George Shuklin <george.shuklin@gmail.com>
   - Volodymyr Rudniev <rudnev.vv@gmail.com>
   - Aleksandr Chudinov <silentirk@me.com>
+  - Dmitrii Rebryshkin <dmitry.r@cyberflow.net>
 description: Collection of modules to work with Servers.com API
 license:
   - GPL-3.0-or-later

--- a/ansible_collections/serverscom/sc_api/meta/runtime.yml
+++ b/ansible_collections/serverscom/sc_api/meta/runtime.yml
@@ -16,6 +16,7 @@ action_groups:
     - cloud_computing_openstack_credentials
     - cloud_computing_regions_info
     - dedicated_server_info
+    - dedicated_server_ipxe
     - dedicated_server_power
     - dedicated_server_rescue
     - dedicated_server_reinstall

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/api.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/api.py
@@ -1143,6 +1143,38 @@ class ScApi:
             retry_rules=retry_rules,
         )
 
+    def post_dedicated_server_feature_activate(
+        self, server_id, feature_name, body=None
+    ):
+        return self.api_helper.make_post_request(
+            path=f"/hosts/dedicated_servers/{server_id}/features/{feature_name}/activate",
+            body=body,
+            query_parameters=None,
+            good_codes=[202],
+        )
+
+    def post_dedicated_server_feature_deactivate(self, server_id, feature_name):
+        return self.api_helper.make_post_request(
+            path=f"/hosts/dedicated_servers/{server_id}/features/{feature_name}/deactivate",
+            body=None,
+            query_parameters=None,
+            good_codes=[202],
+        )
+
+    def put_dedicated_server(self, server_id, body):
+        return self.api_helper.make_put_request(
+            path=f"/hosts/dedicated_servers/{server_id}",
+            body=body,
+            query_parameters=None,
+            good_codes=[200],
+        )
+
+    def get_dedicated_server_features(self, server_id, retry_rules=None):
+        return self.api_helper.make_get_request(
+            path=f"/hosts/dedicated_servers/{server_id}/features",
+            retry_rules=retry_rules,
+        )
+
     def post_dedicated_server_rescue_activate(
         self, server_id, auth_methods, ssh_key_fingerprints=None
     ):

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/api.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/api.py
@@ -1169,12 +1169,6 @@ class ScApi:
             good_codes=[200],
         )
 
-    def get_dedicated_server_features(self, server_id, retry_rules=None):
-        return self.api_helper.make_get_request(
-            path=f"/hosts/dedicated_servers/{server_id}/features",
-            retry_rules=retry_rules,
-        )
-
     def post_dedicated_server_rescue_activate(
         self, server_id, auth_methods, ssh_key_fingerprints=None
     ):

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/dedicated_server.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/dedicated_server.py
@@ -428,13 +428,11 @@ class ScDedicatedServerIpxe:
         return None
 
     def _get_feature_status(self, retry_rules=None):
-        feature = self._get_feature_by_name(
-            self.feature_name, retry_rules=retry_rules
-        )
+        feature = self._get_feature_by_name(self.feature_name, retry_rules=retry_rules)
         if feature is None:
             raise ModuleError(
-                f"Feature '{self.feature_name}' not found "
-                f"for server {self.server_id}"
+                f"Unexpected error, unable to find feature '{self.feature_name}' not found "
+                f"for server {self.server_id}, please contact support"
             )
         return feature
 
@@ -490,46 +488,32 @@ class ScDedicatedServerIpxe:
             )
             feature = None
             if self.wait:
-                feature = self.wait_for_status(
-                    "deactivated", feature_name=feature_name
-                )
+                feature = self.wait_for_status("deactivated", feature_name=feature_name)
             return True, feature
         if status == "activation":
             if self.wait:
-                self.wait_for_status(
-                    "activated", feature_name=feature_name
-                )
+                self.wait_for_status("activated", feature_name=feature_name)
             self.api.post_dedicated_server_feature_deactivate(
                 self.server_id, feature_name
             )
             feature = None
             if self.wait:
-                feature = self.wait_for_status(
-                    "deactivated", feature_name=feature_name
-                )
+                feature = self.wait_for_status("deactivated", feature_name=feature_name)
             return True, feature
         if status == "deactivation":
             feature = None
             if self.wait:
-                feature = self.wait_for_status(
-                    "deactivated", feature_name=feature_name
-                )
+                feature = self.wait_for_status("deactivated", feature_name=feature_name)
             return False, feature
-        raise ModuleError(
-            f"Unexpected status '{status}' for {feature_name}"
-        )
+        raise ModuleError(f"Unexpected status '{status}' for {feature_name}")
 
     def _deactivate_opposite(self, opposite):
-        self._deactivate_feature(
-            self.opposite_feature_name, opposite.get("status")
-        )
+        self._deactivate_feature(self.opposite_feature_name, opposite.get("status"))
 
     def _opposite_needs_deactivation(self, opposite):
         if opposite is None:
             return False
-        return opposite.get("status") in (
-            "activated", "activation", "deactivation"
-        )
+        return opposite.get("status") in ("activated", "activation", "deactivation")
 
     def _ensure_present(self):
         feature = self._get_feature_status()
@@ -572,9 +556,7 @@ class ScDedicatedServerIpxe:
                 feature = self.wait_for_status("activated")
             return {"changed": False, "feature": feature}
 
-        raise ModuleError(
-            f"Unexpected status '{status}' for {self.feature_name}"
-        )
+        raise ModuleError(f"Unexpected status '{status}' for {self.feature_name}")
 
     def _ensure_absent(self):
         features = self.api.get_dedicated_server_features(self.server_id)
@@ -595,9 +577,7 @@ class ScDedicatedServerIpxe:
             if self.checkmode:
                 return {"changed": True, "feature": feature}
 
-            changed, result_feature = self._deactivate_feature(
-                feature_name, status
-            )
+            changed, result_feature = self._deactivate_feature(feature_name, status)
             return {
                 "changed": changed,
                 "feature": result_feature or feature,

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/dedicated_server.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/dedicated_server.py
@@ -387,6 +387,224 @@ class ScDedicatedServerPower:
             raise ModuleError(f"Unknown state: {self.state}")
 
 
+class ScDedicatedServerIpxe:
+    TRANSITIONAL_STATUSES = ("activation", "deactivation")
+
+    def __init__(
+        self,
+        endpoint,
+        token,
+        server_id,
+        ipxe_type,
+        state,
+        ipxe_config,
+        wait,
+        update_interval,
+        checkmode,
+    ):
+        if wait and int(wait) < int(update_interval):
+            raise ModuleError(
+                f"Update interval ({update_interval}) is longer "
+                f"than wait time ({wait})"
+            )
+        self.api = ScApi(token, endpoint)
+        self.server_id = server_id
+        self.feature_name = f"{ipxe_type}_ipxe_boot"
+        opposite_type = "private" if ipxe_type == "public" else "public"
+        self.opposite_feature_name = f"{opposite_type}_ipxe_boot"
+        self.state = state
+        self.ipxe_config = ipxe_config
+        self.wait = wait
+        self.update_interval = update_interval
+        self.checkmode = checkmode
+
+    def _get_feature_by_name(self, feature_name, retry_rules=None):
+        features = self.api.get_dedicated_server_features(
+            self.server_id, retry_rules=retry_rules
+        )
+        for feature in features:
+            if feature.get("name") == feature_name:
+                return feature
+        return None
+
+    def _get_feature_status(self, retry_rules=None):
+        feature = self._get_feature_by_name(
+            self.feature_name, retry_rules=retry_rules
+        )
+        if feature is None:
+            raise ModuleError(
+                f"Feature '{self.feature_name}' not found "
+                f"for server {self.server_id}"
+            )
+        return feature
+
+    def _get_opposite_feature_status(self):
+        return self._get_feature_by_name(self.opposite_feature_name)
+
+    def wait_for_status(self, target_status, feature_name=None):
+        if feature_name is None:
+            feature_name = self.feature_name
+        start = time.time()
+        while True:
+            elapsed = time.time() - start
+            if elapsed > self.wait:
+                raise WaitError(
+                    msg=f"Timeout waiting for {feature_name} "
+                    f"to reach '{target_status}'",
+                    timeout=elapsed,
+                )
+            time.sleep(self.update_interval)
+            elapsed = time.time() - start
+            feature = self._get_feature_by_name(
+                feature_name,
+                retry_rules=_retry_rules_for_wait(
+                    max_wait=max(0, self.wait - elapsed),
+                    delay=self.update_interval,
+                ),
+            )
+            if feature is None:
+                raise ModuleError(
+                    f"Feature '{feature_name}' not found "
+                    f"for server {self.server_id}"
+                )
+            status = feature.get("status")
+            if status == target_status:
+                return feature
+            if status not in self.TRANSITIONAL_STATUSES:
+                raise ModuleError(
+                    f"Unexpected status '{status}' for {feature_name}, "
+                    f"expected '{target_status}'"
+                )
+
+    def _deactivate_opposite(self, opposite):
+        status = opposite.get("status")
+        if status in ("deactivated", "incompatible", "unavailable"):
+            return False
+        if status == "activated":
+            self.api.post_dedicated_server_feature_deactivate(
+                self.server_id, self.opposite_feature_name
+            )
+            if self.wait:
+                self.wait_for_status(
+                    "deactivated",
+                    feature_name=self.opposite_feature_name,
+                )
+            return True
+        if status == "activation":
+            if self.wait:
+                self.wait_for_status(
+                    "activated",
+                    feature_name=self.opposite_feature_name,
+                )
+            self.api.post_dedicated_server_feature_deactivate(
+                self.server_id, self.opposite_feature_name
+            )
+            if self.wait:
+                self.wait_for_status(
+                    "deactivated",
+                    feature_name=self.opposite_feature_name,
+                )
+            return True
+        if status == "deactivation":
+            if self.wait:
+                self.wait_for_status(
+                    "deactivated",
+                    feature_name=self.opposite_feature_name,
+                )
+            return True
+        raise ModuleError(
+            f"Unexpected status '{status}' for "
+            f"{self.opposite_feature_name}"
+        )
+
+    def _opposite_needs_deactivation(self, opposite):
+        if opposite is None:
+            return False
+        return opposite.get("status") in (
+            "activated", "activation", "deactivation"
+        )
+
+    def _ensure_present(self):
+        feature = self._get_feature_status()
+        status = feature.get("status")
+
+        if status == "activated":
+            if self.ipxe_config is not None:
+                server = self.api.get_dedicated_servers(self.server_id)
+                current_config = server.get("ipxe_config") or ""
+                if current_config == self.ipxe_config:
+                    return {"changed": False, "feature": feature}
+                if self.checkmode:
+                    return {"changed": True, "feature": feature}
+                self.api.put_dedicated_server(
+                    self.server_id, {"ipxe_config": self.ipxe_config}
+                )
+                return {"changed": True, "feature": feature}
+            return {"changed": False, "feature": feature}
+
+        if status in ("deactivated", "incompatible", "unavailable"):
+            opposite = self._get_opposite_feature_status()
+            if self._opposite_needs_deactivation(opposite):
+                if self.checkmode:
+                    return {"changed": True, "feature": feature}
+                self._deactivate_opposite(opposite)
+            if self.checkmode:
+                return {"changed": True, "feature": feature}
+            body = {}
+            if self.ipxe_config is not None:
+                body["ipxe_config"] = self.ipxe_config
+            self.api.post_dedicated_server_feature_activate(
+                self.server_id, self.feature_name, body=body or None
+            )
+            if self.wait:
+                feature = self.wait_for_status("activated")
+            return {"changed": True, "feature": feature}
+
+        if status == "activation":
+            if self.wait:
+                feature = self.wait_for_status("activated")
+            return {"changed": False, "feature": feature}
+
+        raise ModuleError(
+            f"Unexpected status '{status}' for {self.feature_name}"
+        )
+
+    def _ensure_absent(self):
+        feature = self._get_feature_status()
+        status = feature.get("status")
+
+        if status == "deactivated":
+            return {"changed": False, "feature": feature}
+
+        if status == "activated":
+            if self.checkmode:
+                return {"changed": True, "feature": feature}
+            self.api.post_dedicated_server_feature_deactivate(
+                self.server_id, self.feature_name
+            )
+            if self.wait:
+                feature = self.wait_for_status("deactivated")
+            return {"changed": True, "feature": feature}
+
+        if status == "deactivation":
+            if self.wait:
+                feature = self.wait_for_status("deactivated")
+            return {"changed": False, "feature": feature}
+
+        if status in ("incompatible", "unavailable"):
+            return {"changed": False, "feature": feature}
+
+        raise ModuleError(
+            f"Unexpected status '{status}' for {self.feature_name}"
+        )
+
+    def run(self):
+        if self.state == "present":
+            return self._ensure_present()
+        else:
+            return self._ensure_absent()
+
+
 class ScDedicatedOSList:
     def __init__(
         self,

--- a/ansible_collections/serverscom/sc_api/plugins/module_utils/dedicated_server.py
+++ b/ansible_collections/serverscom/sc_api/plugins/module_utils/dedicated_server.py
@@ -395,7 +395,6 @@ class ScDedicatedServerIpxe:
         endpoint,
         token,
         server_id,
-        ipxe_type,
         state,
         ipxe_config,
         wait,
@@ -409,10 +408,11 @@ class ScDedicatedServerIpxe:
             )
         self.api = ScApi(token, endpoint)
         self.server_id = server_id
-        self.feature_name = f"{ipxe_type}_ipxe_boot"
-        opposite_type = "private" if ipxe_type == "public" else "public"
-        self.opposite_feature_name = f"{opposite_type}_ipxe_boot"
         self.state = state
+        if state in ("public", "private"):
+            self.feature_name = f"{state}_ipxe_boot"
+            opposite = "private" if state == "public" else "public"
+            self.opposite_feature_name = f"{opposite}_ipxe_boot"
         self.ipxe_config = ipxe_config
         self.wait = wait
         self.update_interval = update_interval
@@ -476,45 +476,52 @@ class ScDedicatedServerIpxe:
                     f"expected '{target_status}'"
                 )
 
-    def _deactivate_opposite(self, opposite):
-        status = opposite.get("status")
+    def _deactivate_feature(self, feature_name, status):
+        """Deactivate a feature handling all possible statuses.
+
+        Returns (changed, feature) where changed indicates whether
+        a deactivation was initiated by us.
+        """
         if status in ("deactivated", "incompatible", "unavailable"):
-            return False
+            return False, None
         if status == "activated":
             self.api.post_dedicated_server_feature_deactivate(
-                self.server_id, self.opposite_feature_name
+                self.server_id, feature_name
             )
+            feature = None
             if self.wait:
-                self.wait_for_status(
-                    "deactivated",
-                    feature_name=self.opposite_feature_name,
+                feature = self.wait_for_status(
+                    "deactivated", feature_name=feature_name
                 )
-            return True
+            return True, feature
         if status == "activation":
             if self.wait:
                 self.wait_for_status(
-                    "activated",
-                    feature_name=self.opposite_feature_name,
+                    "activated", feature_name=feature_name
                 )
             self.api.post_dedicated_server_feature_deactivate(
-                self.server_id, self.opposite_feature_name
+                self.server_id, feature_name
             )
+            feature = None
             if self.wait:
-                self.wait_for_status(
-                    "deactivated",
-                    feature_name=self.opposite_feature_name,
+                feature = self.wait_for_status(
+                    "deactivated", feature_name=feature_name
                 )
-            return True
+            return True, feature
         if status == "deactivation":
+            feature = None
             if self.wait:
-                self.wait_for_status(
-                    "deactivated",
-                    feature_name=self.opposite_feature_name,
+                feature = self.wait_for_status(
+                    "deactivated", feature_name=feature_name
                 )
-            return True
+            return False, feature
         raise ModuleError(
-            f"Unexpected status '{status}' for "
-            f"{self.opposite_feature_name}"
+            f"Unexpected status '{status}' for {feature_name}"
+        )
+
+    def _deactivate_opposite(self, opposite):
+        self._deactivate_feature(
+            self.opposite_feature_name, opposite.get("status")
         )
 
     def _opposite_needs_deactivation(self, opposite):
@@ -570,36 +577,40 @@ class ScDedicatedServerIpxe:
         )
 
     def _ensure_absent(self):
-        feature = self._get_feature_status()
-        status = feature.get("status")
+        features = self.api.get_dedicated_server_features(self.server_id)
+        for feature_name in ("public_ipxe_boot", "private_ipxe_boot"):
+            feature = None
+            for f in features:
+                if f.get("name") == feature_name:
+                    feature = f
+                    break
+            if feature is None:
+                continue
 
-        if status == "deactivated":
-            return {"changed": False, "feature": feature}
+            status = feature.get("status")
 
-        if status == "activated":
+            if status in ("deactivated", "incompatible", "unavailable"):
+                continue
+
             if self.checkmode:
                 return {"changed": True, "feature": feature}
-            self.api.post_dedicated_server_feature_deactivate(
-                self.server_id, self.feature_name
+
+            changed, result_feature = self._deactivate_feature(
+                feature_name, status
             )
-            if self.wait:
-                feature = self.wait_for_status("deactivated")
-            return {"changed": True, "feature": feature}
+            return {
+                "changed": changed,
+                "feature": result_feature or feature,
+            }
 
-        if status == "deactivation":
-            if self.wait:
-                feature = self.wait_for_status("deactivated")
-            return {"changed": False, "feature": feature}
-
-        if status in ("incompatible", "unavailable"):
-            return {"changed": False, "feature": feature}
-
-        raise ModuleError(
-            f"Unexpected status '{status}' for {self.feature_name}"
-        )
+        # Both features are inactive or absent
+        for f in features:
+            if f.get("name") in ("public_ipxe_boot", "private_ipxe_boot"):
+                return {"changed": False, "feature": f}
+        return {"changed": False, "feature": {}}
 
     def run(self):
-        if self.state == "present":
+        if self.state in ("public", "private"):
             return self._ensure_present()
         else:
             return self._ensure_absent()

--- a/ansible_collections/serverscom/sc_api/plugins/modules/dedicated_server_ipxe.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/dedicated_server_ipxe.py
@@ -24,10 +24,6 @@ description: >
     Activate or deactivate the public or private iPXE boot feature on a
     dedicated server. Optionally update the iPXE configuration script on an
     already activated feature.
-    When activating a feature while the opposite type is active (e.g.
-    switching from public to private), the module automatically deactivates
-    the opposite feature first, waits for it to finish, and then activates
-    the requested one.
 
 extends_documentation_fragment: serverscom.sc_api.api_auth
 
@@ -39,30 +35,26 @@ options:
       - ID of the dedicated server.
       - Use M(serverscom.sc_api.dedicated_server_info) to retrieve servers.
 
-  type:
-    type: str
-    required: true
-    choices: ['public', 'private']
-    description:
-      - Type of iPXE boot feature to manage.
-      - C(public) manages the public_ipxe_boot feature.
-      - C(private) manages the private_ipxe_boot feature.
-
   state:
     type: str
     required: true
-    choices: ['present', 'absent']
+    choices: ['absent', 'public', 'private']
     description:
       - Desired state of the iPXE boot feature.
-      - C(present) activates the feature (or updates iPXE config if already active).
-      - C(absent) deactivates the feature.
+      - C(public) activates the public_ipxe_boot feature (or updates iPXE
+        config if already active). Automatically deactivates private_ipxe_boot
+        if it is active.
+      - C(private) activates the private_ipxe_boot feature (or updates iPXE
+        config if already active). Automatically deactivates public_ipxe_boot
+        if it is active.
+      - C(absent) deactivates whichever iPXE boot feature is currently active.
 
   ipxe_config:
     type: str
     required: false
     description:
       - iPXE script content (max 64 KB).
-      - Required when I(state)=C(present).
+      - Required when I(state) is C(public) or C(private).
       - When the feature is already activated the configuration is updated via
         the server update endpoint.
 
@@ -104,47 +96,24 @@ EXAMPLES = """
   serverscom.sc_api.dedicated_server_ipxe:
     token: "{{ api_token }}"
     server_id: "0m592Zmn"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
 
-- name: Activate private iPXE boot with custom config
+- name: Activate private iPXE boot
   serverscom.sc_api.dedicated_server_ipxe:
     token: "{{ api_token }}"
     server_id: "0m592Zmn"
-    type: private
-    state: present
+    state: private
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
 
-- name: Update iPXE config on already activated feature
+- name: Deactivate whichever iPXE boot is active
   serverscom.sc_api.dedicated_server_ipxe:
     token: "{{ api_token }}"
     server_id: "0m592Zmn"
-    type: public
-    state: present
-    ipxe_config: |
-      #!ipxe
-      chain http://boot.example.com/new-menu.ipxe
-
-- name: Switch from public to private iPXE boot
-  serverscom.sc_api.dedicated_server_ipxe:
-    token: "{{ api_token }}"
-    server_id: "0m592Zmn"
-    type: private
-    state: present
-    ipxe_config: |
-      #!ipxe
-      chain http://boot.example.com/private-menu.ipxe
-
-- name: Deactivate public iPXE boot
-  serverscom.sc_api.dedicated_server_ipxe:
-    token: "{{ api_token }}"
-    server_id: "0m592Zmn"
-    type: public
     state: absent
 """
 
@@ -163,14 +132,9 @@ def main():
         argument_spec={
             **AUTH_ARGS,
             "server_id": {"type": "str", "required": True},
-            "type": {
-                "type": "str",
-                "choices": ["public", "private"],
-                "required": True,
-            },
             "state": {
                 "type": "str",
-                "choices": ["present", "absent"],
+                "choices": ["absent", "public", "private"],
                 "required": True,
             },
             "ipxe_config": {"type": "str", "no_log": False},
@@ -178,7 +142,8 @@ def main():
             "update_interval": {"type": "int", "default": 10},
         },
         required_if=[
-            ["state", "present", ["ipxe_config"]],
+            ["state", "public", ["ipxe_config"]],
+            ["state", "private", ["ipxe_config"]],
         ],
         supports_check_mode=True,
     )
@@ -188,7 +153,6 @@ def main():
             endpoint=module.params["endpoint"],
             token=module.params["token"],
             server_id=module.params["server_id"],
-            ipxe_type=module.params["type"],
             state=module.params["state"],
             ipxe_config=module.params["ipxe_config"],
             wait=module.params["wait"],

--- a/ansible_collections/serverscom/sc_api/plugins/modules/dedicated_server_ipxe.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/dedicated_server_ipxe.py
@@ -1,0 +1,204 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2026, Servers.com
+# GNU General Public License v3.0
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: dedicated_server_ipxe
+version_added: "1.0.0"
+author: "Servers.com Team (@serverscom)"
+short_description: Manage iPXE boot feature on dedicated servers
+description: >
+    Activate or deactivate the public or private iPXE boot feature on a
+    dedicated server. Optionally update the iPXE configuration script on an
+    already activated feature.
+    When activating a feature while the opposite type is active (e.g.
+    switching from public to private), the module automatically deactivates
+    the opposite feature first, waits for it to finish, and then activates
+    the requested one.
+
+extends_documentation_fragment: serverscom.sc_api.api_auth
+
+options:
+  server_id:
+    type: str
+    required: true
+    description:
+      - ID of the dedicated server.
+      - Use M(serverscom.sc_api.dedicated_server_info) to retrieve servers.
+
+  type:
+    type: str
+    required: true
+    choices: ['public', 'private']
+    description:
+      - Type of iPXE boot feature to manage.
+      - C(public) manages the public_ipxe_boot feature.
+      - C(private) manages the private_ipxe_boot feature.
+
+  state:
+    type: str
+    required: true
+    choices: ['present', 'absent']
+    description:
+      - Desired state of the iPXE boot feature.
+      - C(present) activates the feature (or updates iPXE config if already active).
+      - C(absent) deactivates the feature.
+
+  ipxe_config:
+    type: str
+    required: false
+    description:
+      - iPXE script content (max 64 KB).
+      - Required when I(state)=C(present).
+      - When the feature is already activated the configuration is updated via
+        the server update endpoint.
+
+  wait:
+    type: int
+    required: false
+    default: 600
+    description:
+      - Maximum time in seconds to wait for the feature to reach the desired
+        status after activation or deactivation.
+      - Set to C(0) to return immediately without waiting.
+
+  update_interval:
+    type: int
+    required: false
+    default: 10
+    description:
+      - Polling interval in seconds when waiting for the feature status change.
+"""
+
+RETURN = """
+feature:
+  description: Feature object returned by the API.
+  type: dict
+  returned: on success
+  contains:
+    name:
+      description: Feature name (e.g. public_ipxe_boot, private_ipxe_boot).
+      type: str
+    status:
+      description: >
+        Current feature status (activation, activated, deactivation,
+        deactivated, incompatible, unavailable).
+      type: str
+"""
+
+EXAMPLES = """
+- name: Activate public iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    token: "{{ api_token }}"
+    server_id: "0m592Zmn"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+
+- name: Activate private iPXE boot with custom config
+  serverscom.sc_api.dedicated_server_ipxe:
+    token: "{{ api_token }}"
+    server_id: "0m592Zmn"
+    type: private
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+
+- name: Update iPXE config on already activated feature
+  serverscom.sc_api.dedicated_server_ipxe:
+    token: "{{ api_token }}"
+    server_id: "0m592Zmn"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/new-menu.ipxe
+
+- name: Switch from public to private iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    token: "{{ api_token }}"
+    server_id: "0m592Zmn"
+    type: private
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/private-menu.ipxe
+
+- name: Deactivate public iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    token: "{{ api_token }}"
+    server_id: "0m592Zmn"
+    type: public
+    state: absent
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.serverscom.sc_api.plugins.module_utils.modules import (
+    AUTH_ARGS,
+    SCBaseError,
+)
+from ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server import (
+    ScDedicatedServerIpxe,
+)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            **AUTH_ARGS,
+            "server_id": {"type": "str", "required": True},
+            "type": {
+                "type": "str",
+                "choices": ["public", "private"],
+                "required": True,
+            },
+            "state": {
+                "type": "str",
+                "choices": ["present", "absent"],
+                "required": True,
+            },
+            "ipxe_config": {"type": "str", "no_log": False},
+            "wait": {"type": "int", "default": 600},
+            "update_interval": {"type": "int", "default": 10},
+        },
+        required_if=[
+            ["state", "present", ["ipxe_config"]],
+        ],
+        supports_check_mode=True,
+    )
+
+    try:
+        ipxe = ScDedicatedServerIpxe(
+            endpoint=module.params["endpoint"],
+            token=module.params["token"],
+            server_id=module.params["server_id"],
+            ipxe_type=module.params["type"],
+            state=module.params["state"],
+            ipxe_config=module.params["ipxe_config"],
+            wait=module.params["wait"],
+            update_interval=module.params["update_interval"],
+            checkmode=module.check_mode,
+        )
+        module.exit_json(**ipxe.run())
+    except SCBaseError as e:
+        module.exit_json(**e.fail())
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_ipxe/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_ipxe/tasks/main.yaml
@@ -1,0 +1,300 @@
+---
+- name: Check if there are sc_token and sc_endpoint variables
+  no_log: true
+  fail:
+    msg: "You need to define sc_token and sc_endpoint variables in tests/integration/integration_config.yml"
+  when: not sc_endpoint or not sc_token
+
+# --- Activate public iPXE boot ---
+
+- name: Activate public iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    wait: 600
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: activate_public
+
+- name: Verify activate public iPXE boot
+  assert:
+    that:
+      - activate_public is changed
+      - activate_public.feature.name == "public_ipxe_boot"
+      - activate_public.feature.status == "activated"
+
+- name: Activate public iPXE boot (idempotency)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: activate_public_idem
+
+- name: Verify activate public iPXE boot idempotency
+  assert:
+    that:
+      - activate_public_idem is not changed
+      - activate_public_idem.feature.status == "activated"
+
+# --- Update iPXE config on activated feature ---
+
+- name: Update iPXE config on activated public feature
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: update_config
+
+- name: Verify iPXE config update
+  assert:
+    that:
+      - update_config.feature.name == "public_ipxe_boot"
+      - update_config.feature.status == "activated"
+
+# --- Check mode for deactivation ---
+
+- name: Deactivate public iPXE boot (check mode)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: absent
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  check_mode: true
+  register: deactivate_check
+
+- name: Verify check mode deactivation reports changed
+  assert:
+    that:
+      - deactivate_check is changed
+
+# --- Deactivate public iPXE boot ---
+
+- name: Deactivate public iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: absent
+    wait: 600
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: deactivate_public
+
+- name: Verify deactivate public iPXE boot
+  assert:
+    that:
+      - deactivate_public is changed
+      - deactivate_public.feature.name == "public_ipxe_boot"
+      - deactivate_public.feature.status == "deactivated"
+
+- name: Deactivate public iPXE boot (idempotency)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: absent
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: deactivate_public_idem
+
+- name: Verify deactivate public iPXE boot idempotency
+  assert:
+    that:
+      - deactivate_public_idem is not changed
+      - deactivate_public_idem.feature.status == "deactivated"
+
+# --- Check mode for activation ---
+
+- name: Activate public iPXE boot (check mode)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  check_mode: true
+  register: activate_check
+
+- name: Verify check mode activation reports changed
+  assert:
+    that:
+      - activate_check is changed
+
+- name: Confirm feature is still deactivated after check mode
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: absent
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: after_check
+
+- name: Verify still deactivated after check mode
+  assert:
+    that:
+      - after_check is not changed
+      - after_check.feature.status == "deactivated"
+
+# --- Switch mode: public -> private -> public ---
+
+- name: Activate public iPXE boot (setup for switch)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    wait: 600
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: setup_public
+
+- name: Verify public is activated for switch test
+  assert:
+    that:
+      - setup_public.feature.status == "activated"
+
+- name: Switch from public to private iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: private
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/private-menu.ipxe
+    wait: 600
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: switch_to_private
+
+- name: Verify switch to private
+  assert:
+    that:
+      - switch_to_private is changed
+      - switch_to_private.feature.name == "private_ipxe_boot"
+      - switch_to_private.feature.status == "activated"
+
+- name: Switch to private iPXE boot (idempotency)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: private
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/private-menu.ipxe
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: switch_to_private_idem
+
+- name: Verify switch to private idempotency
+  assert:
+    that:
+      - switch_to_private_idem is not changed
+      - switch_to_private_idem.feature.status == "activated"
+
+- name: Switch from private back to public iPXE boot
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    wait: 600
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: switch_to_public
+
+- name: Verify switch back to public
+  assert:
+    that:
+      - switch_to_public is changed
+      - switch_to_public.feature.name == "public_ipxe_boot"
+      - switch_to_public.feature.status == "activated"
+
+- name: Switch to public iPXE boot (check mode)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: private
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/private-menu.ipxe
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  check_mode: true
+  register: switch_check
+
+- name: Verify check mode switch reports changed
+  assert:
+    that:
+      - switch_check is changed
+
+- name: Confirm public is still activated after check mode switch
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: present
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    wait: 0
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: after_switch_check
+
+- name: Verify public still activated after check mode switch
+  assert:
+    that:
+      - after_switch_check is not changed
+      - after_switch_check.feature.status == "activated"
+
+# --- Cleanup ---
+
+- name: Deactivate public iPXE boot (cleanup)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
+    type: public
+    state: absent
+    wait: 600
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_ipxe/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_ipxe/tasks/main.yaml
@@ -10,8 +10,7 @@
 - name: Activate public iPXE boot
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
@@ -31,8 +30,7 @@
 - name: Activate public iPXE boot (idempotency)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
@@ -53,11 +51,10 @@
 - name: Update iPXE config on activated public feature
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
-      chain http://boot.example.com/menu.ipxe
+      chain http://boot.example.com/updated-menu.ipxe
   environment:
     SERVERSCOM_API_TOKEN: '{{ sc_token }}'
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -66,15 +63,33 @@
 - name: Verify iPXE config update
   assert:
     that:
+      - update_config is changed
       - update_config.feature.name == "public_ipxe_boot"
       - update_config.feature.status == "activated"
 
-# --- Check mode for deactivation ---
-
-- name: Deactivate public iPXE boot (check mode)
+- name: Update iPXE config on activated public feature (idempotency)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
+    state: public
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/updated-menu.ipxe
+  environment:
+    SERVERSCOM_API_TOKEN: '{{ sc_token }}'
+    SERVERSCOM_API_URL: '{{ sc_endpoint }}'
+  register: update_config_idem
+
+- name: Verify iPXE config update idempotency
+  assert:
+    that:
+      - update_config_idem is not changed
+      - update_config_idem.feature.status == "activated"
+
+# --- Check mode for deactivation ---
+
+- name: Deactivate iPXE boot (check mode)
+  serverscom.sc_api.dedicated_server_ipxe:
+    server_id: "{{ existing_server1_id }}"
     state: absent
     wait: 0
   environment:
@@ -88,12 +103,11 @@
     that:
       - deactivate_check is changed
 
-# --- Deactivate public iPXE boot ---
+# --- Deactivate iPXE boot ---
 
-- name: Deactivate public iPXE boot
+- name: Deactivate iPXE boot
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
     state: absent
     wait: 600
   environment:
@@ -101,17 +115,16 @@
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'
   register: deactivate_public
 
-- name: Verify deactivate public iPXE boot
+- name: Verify deactivate iPXE boot
   assert:
     that:
       - deactivate_public is changed
       - deactivate_public.feature.name == "public_ipxe_boot"
       - deactivate_public.feature.status == "deactivated"
 
-- name: Deactivate public iPXE boot (idempotency)
+- name: Deactivate iPXE boot (idempotency)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
     state: absent
     wait: 0
   environment:
@@ -119,19 +132,17 @@
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'
   register: deactivate_public_idem
 
-- name: Verify deactivate public iPXE boot idempotency
+- name: Verify deactivate iPXE boot idempotency
   assert:
     that:
       - deactivate_public_idem is not changed
-      - deactivate_public_idem.feature.status == "deactivated"
 
 # --- Check mode for activation ---
 
 - name: Activate public iPXE boot (check mode)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
@@ -150,7 +161,6 @@
 - name: Confirm feature is still deactivated after check mode
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
     state: absent
     wait: 0
   environment:
@@ -162,15 +172,13 @@
   assert:
     that:
       - after_check is not changed
-      - after_check.feature.status == "deactivated"
 
 # --- Switch mode: public -> private -> public ---
 
 - name: Activate public iPXE boot (setup for switch)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
@@ -188,8 +196,7 @@
 - name: Switch from public to private iPXE boot
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: private
-    state: present
+    state: private
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/private-menu.ipxe
@@ -209,8 +216,7 @@
 - name: Switch to private iPXE boot (idempotency)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: private
-    state: present
+    state: private
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/private-menu.ipxe
@@ -229,8 +235,7 @@
 - name: Switch from private back to public iPXE boot
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
@@ -247,11 +252,10 @@
       - switch_to_public.feature.name == "public_ipxe_boot"
       - switch_to_public.feature.status == "activated"
 
-- name: Switch to public iPXE boot (check mode)
+- name: Switch to private iPXE boot (check mode)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: private
-    state: present
+    state: private
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/private-menu.ipxe
@@ -270,8 +274,7 @@
 - name: Confirm public is still activated after check mode switch
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
-    state: present
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
@@ -289,10 +292,9 @@
 
 # --- Cleanup ---
 
-- name: Deactivate public iPXE boot (cleanup)
+- name: Deactivate iPXE boot (cleanup)
   serverscom.sc_api.dedicated_server_ipxe:
     server_id: "{{ existing_server1_id }}"
-    type: public
     state: absent
     wait: 600
   environment:

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_no_token_tests/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_no_token_tests/tasks/main.yaml
@@ -215,6 +215,27 @@
       - result.status_code == 401
       - "'token' in result.msg"
 
+- name: dedicated_server_ipxe
+  serverscom.sc_api.dedicated_server_ipxe:
+    token: dummy
+    endpoint: "https://api.servers.com/v1"
+    server_id: "test123"
+    type: public
+    ipxe_config: |
+      #!ipxe
+      chain http://boot.example.com/menu.ipxe
+    state: present
+    wait: 0
+  register: result
+  ignore_errors: true
+
+- name: Verify dedicated_server_ipxe
+  assert:
+    that:
+      - result is failed
+      - result.status_code == 401
+      - "'token' in result.msg"
+
 - name: sc_dedicated_server_reinstall
   serverscom.sc_api.dedicated_server_reinstall:
     token: dummy

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_no_token_tests/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sc_no_token_tests/tasks/main.yaml
@@ -220,11 +220,10 @@
     token: dummy
     endpoint: "https://api.servers.com/v1"
     server_id: "test123"
-    type: public
+    state: public
     ipxe_config: |
       #!ipxe
       chain http://boot.example.com/menu.ipxe
-    state: present
     wait: 0
   register: result
   ignore_errors: true

--- a/ansible_collections/serverscom/sc_api/tests/unit/plugins/modules/test_api.py
+++ b/ansible_collections/serverscom/sc_api/tests/unit/plugins/modules/test_api.py
@@ -204,6 +204,118 @@ def test_decode_error_includes_correlation_id(api_helper, clock):
     assert "decode-456" in exc_info.value.msg
 
 
+@pytest.fixture
+def sc_api_obj():
+    return sc_api.ScApi(token="token", endpoint="http://api")
+
+
+class TestGetDedicatedServerFeatures:
+    def test_returns_features_list(self, sc_api_obj, clock):
+        features = [
+            {"name": "public_ipxe_boot", "status": "deactivated"},
+            {"name": "private_ipxe_boot", "status": "activated"},
+        ]
+        sequencer = SendSequencer([FakeResponse(200, {}, json_data=features)])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        result = sc_api_obj.get_dedicated_server_features("srv123")
+
+        assert result == features
+        assert sequencer.calls == 1
+
+    def test_passes_retry_rules(self, sc_api_obj, clock):
+        features = [{"name": "public_ipxe_boot", "status": "activated"}]
+        sequencer = SendSequencer([
+            FakeResponse(429, {}),
+            FakeResponse(200, {}, json_data=features),
+        ])
+        sc_api_obj.api_helper.session.send = sequencer
+        retry_rules = {"codes": {429}, "delay": 1, "max_wait": 10}
+
+        result = sc_api_obj.get_dedicated_server_features("srv123", retry_rules=retry_rules)
+
+        assert result == features
+        assert sequencer.calls == 2
+
+    def test_401_raises_error(self, sc_api_obj, clock):
+        sequencer = SendSequencer([FakeResponse(401, {})])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        with pytest.raises(sc_api.APIError401):
+            sc_api_obj.get_dedicated_server_features("srv123")
+
+
+class TestPostDedicatedServerFeatureActivate:
+    def test_activate_without_body(self, sc_api_obj, clock):
+        feature = {"name": "public_ipxe_boot", "status": "activation"}
+        sequencer = SendSequencer([FakeResponse(202, {}, json_data=feature)])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        result = sc_api_obj.post_dedicated_server_feature_activate("srv123", "public_ipxe_boot")
+
+        assert result == feature
+        assert sequencer.calls == 1
+
+    def test_activate_with_body(self, sc_api_obj, clock):
+        feature = {"name": "public_ipxe_boot", "status": "activation"}
+        sequencer = SendSequencer([FakeResponse(202, {}, json_data=feature)])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        result = sc_api_obj.post_dedicated_server_feature_activate(
+            "srv123", "public_ipxe_boot", body={"ipxe_config": "#!ipxe\nchain http://example.com"}
+        )
+
+        assert result == feature
+
+    def test_401_raises_error(self, sc_api_obj, clock):
+        sequencer = SendSequencer([FakeResponse(401, {})])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        with pytest.raises(sc_api.APIError401):
+            sc_api_obj.post_dedicated_server_feature_activate("srv123", "public_ipxe_boot")
+
+
+class TestPostDedicatedServerFeatureDeactivate:
+    def test_deactivate(self, sc_api_obj, clock):
+        feature = {"name": "public_ipxe_boot", "status": "deactivation"}
+        sequencer = SendSequencer([FakeResponse(202, {}, json_data=feature)])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        result = sc_api_obj.post_dedicated_server_feature_deactivate("srv123", "public_ipxe_boot")
+
+        assert result == feature
+        assert sequencer.calls == 1
+
+    def test_401_raises_error(self, sc_api_obj, clock):
+        sequencer = SendSequencer([FakeResponse(401, {})])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        with pytest.raises(sc_api.APIError401):
+            sc_api_obj.post_dedicated_server_feature_deactivate("srv123", "public_ipxe_boot")
+
+
+class TestPutDedicatedServer:
+    def test_update_ipxe_config(self, sc_api_obj, clock):
+        server = {"id": "srv123", "ipxe_config": "#!ipxe\nnew"}
+        sequencer = SendSequencer([FakeResponse(200, {}, json_data=server)])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        status_code, result = sc_api_obj.put_dedicated_server(
+            "srv123", {"ipxe_config": "#!ipxe\nnew"}
+        )
+
+        assert status_code == 200
+        assert result == server
+        assert sequencer.calls == 1
+
+    def test_401_raises_error(self, sc_api_obj, clock):
+        sequencer = SendSequencer([FakeResponse(401, {})])
+        sc_api_obj.api_helper.session.send = sequencer
+
+        with pytest.raises(sc_api.APIError401):
+            sc_api_obj.put_dedicated_server("srv123", {"ipxe_config": "x"})
+
+
 def test_correlation_id_all_error_codes(api_helper, clock):
     headers = {"X-Correlation-ID": "test-corr"}
     error_map = {

--- a/ansible_collections/serverscom/sc_api/tests/unit/plugins/modules/test_dedicated_server_ipxe.py
+++ b/ansible_collections/serverscom/sc_api/tests/unit/plugins/modules/test_dedicated_server_ipxe.py
@@ -27,13 +27,12 @@ def _make_feature(name, status, ipxe_config=None):
     return f
 
 
-def _make_handler(ipxe_type="public", state="present", ipxe_config=None,
+def _make_handler(state="public", ipxe_config=None,
                   wait=0, update_interval=10, checkmode=False):
     return ScDedicatedServerIpxe(
         endpoint=ENDPOINT,
         token=TOKEN,
         server_id=SERVER_ID,
-        ipxe_type=ipxe_type,
         state=state,
         ipxe_config=ipxe_config,
         wait=wait,
@@ -45,7 +44,7 @@ def _make_handler(ipxe_type="public", state="present", ipxe_config=None,
 class TestActivate:
     def test_activate_public_ipxe(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         features = [
@@ -68,7 +67,7 @@ class TestActivate:
 
     def test_activate_private_ipxe(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         features = [
@@ -91,7 +90,7 @@ class TestActivate:
 
     def test_activate_with_ipxe_config(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nchain http://boot.example.com"
         )
         features = [_make_feature("public_ipxe_boot", "deactivated")]
@@ -108,7 +107,7 @@ class TestActivate:
 
     def test_activate_already_active_same_config(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="existing-config",
         )
         features = [
@@ -125,7 +124,7 @@ class TestActivate:
 
     def test_activate_already_active_with_config_update(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nnew-config"
         )
         features = [
@@ -145,7 +144,7 @@ class TestActivate:
 
     def test_activate_already_active_config_unchanged(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="same-config"
         )
         features = [
@@ -162,7 +161,7 @@ class TestActivate:
 
     def test_activate_from_incompatible(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         features = [_make_feature("public_ipxe_boot", "incompatible")]
@@ -176,7 +175,7 @@ class TestActivate:
 
     def test_activate_from_unavailable(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         features = [_make_feature("public_ipxe_boot", "unavailable")]
@@ -190,7 +189,7 @@ class TestActivate:
 
     def test_activate_already_in_activation(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
             wait=0,
         )
@@ -205,9 +204,12 @@ class TestActivate:
 
 
 class TestDeactivate:
-    def test_deactivate_ipxe(self):
+    def test_deactivate_public_active(self):
         handler = _make_handler(state="absent")
-        features = [_make_feature("public_ipxe_boot", "activated")]
+        features = [
+            _make_feature("public_ipxe_boot", "activated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -218,9 +220,28 @@ class TestDeactivate:
             SERVER_ID, "public_ipxe_boot"
         )
 
-    def test_deactivate_already_inactive(self):
+    def test_deactivate_private_active(self):
         handler = _make_handler(state="absent")
-        features = [_make_feature("public_ipxe_boot", "deactivated")]
+        features = [
+            _make_feature("public_ipxe_boot", "deactivated"),
+            _make_feature("private_ipxe_boot", "activated"),
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "private_ipxe_boot"
+        )
+
+    def test_deactivate_both_already_inactive(self):
+        handler = _make_handler(state="absent")
+        features = [
+            _make_feature("public_ipxe_boot", "deactivated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -231,7 +252,10 @@ class TestDeactivate:
 
     def test_deactivate_already_in_deactivation(self):
         handler = _make_handler(state="absent", wait=0)
-        features = [_make_feature("public_ipxe_boot", "deactivation")]
+        features = [
+            _make_feature("public_ipxe_boot", "deactivation"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -242,7 +266,10 @@ class TestDeactivate:
 
     def test_deactivate_incompatible(self):
         handler = _make_handler(state="absent")
-        features = [_make_feature("public_ipxe_boot", "incompatible")]
+        features = [
+            _make_feature("public_ipxe_boot", "incompatible"),
+            _make_feature("private_ipxe_boot", "incompatible"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -252,7 +279,10 @@ class TestDeactivate:
 
     def test_deactivate_unavailable(self):
         handler = _make_handler(state="absent")
-        features = [_make_feature("public_ipxe_boot", "unavailable")]
+        features = [
+            _make_feature("public_ipxe_boot", "unavailable"),
+            _make_feature("private_ipxe_boot", "unavailable"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -260,11 +290,28 @@ class TestDeactivate:
 
         assert result["changed"] is False
 
+    def test_deactivate_feature_in_activation(self):
+        """If a feature is being activated, absent should wait then deactivate."""
+        handler = _make_handler(state="absent", wait=0)
+        features = [
+            _make_feature("public_ipxe_boot", "activation"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot"
+        )
+
 
 class TestCheckMode:
     def test_activate_checkmode(self):
         handler = _make_handler(
-            state="present", checkmode=True,
+            state="public", checkmode=True,
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         features = [_make_feature("public_ipxe_boot", "deactivated")]
@@ -279,7 +326,7 @@ class TestCheckMode:
     def test_activate_checkmode_already_active_same_config(self):
         """In check mode with matching ipxe_config, changed=False."""
         handler = _make_handler(
-            state="present", checkmode=True,
+            state="public", checkmode=True,
             ipxe_config="existing-config",
         )
         features = [
@@ -296,7 +343,7 @@ class TestCheckMode:
 
     def test_activate_checkmode_with_different_config(self):
         handler = _make_handler(
-            state="present", checkmode=True, ipxe_config="new"
+            state="public", checkmode=True, ipxe_config="new"
         )
         features = [_make_feature("public_ipxe_boot", "activated")]
         handler.api = mock.MagicMock()
@@ -310,7 +357,10 @@ class TestCheckMode:
 
     def test_deactivate_checkmode(self):
         handler = _make_handler(state="absent", checkmode=True)
-        features = [_make_feature("public_ipxe_boot", "activated")]
+        features = [
+            _make_feature("public_ipxe_boot", "activated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -321,7 +371,10 @@ class TestCheckMode:
 
     def test_deactivate_checkmode_already_inactive(self):
         handler = _make_handler(state="absent", checkmode=True)
-        features = [_make_feature("public_ipxe_boot", "deactivated")]
+        features = [
+            _make_feature("public_ipxe_boot", "deactivated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.return_value = features
 
@@ -333,7 +386,7 @@ class TestCheckMode:
 class TestModeSwitch:
     def test_switch_public_to_private(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         handler.api = mock.MagicMock()
@@ -363,7 +416,7 @@ class TestModeSwitch:
 
     def test_switch_private_to_public(self):
         handler = _make_handler(
-            ipxe_type="public", state="present",
+            state="public",
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         handler.api = mock.MagicMock()
@@ -402,7 +455,7 @@ class TestModeSwitch:
         mock_time.sleep = mock.MagicMock()
 
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest", wait=60, update_interval=5,
         )
         handler.api = mock.MagicMock()
@@ -442,7 +495,7 @@ class TestModeSwitch:
 
     def test_switch_opposite_in_deactivation_no_wait(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest", wait=0,
         )
         handler.api = mock.MagicMock()
@@ -466,7 +519,7 @@ class TestModeSwitch:
 
     def test_switch_with_wait_zero(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest", wait=0,
         )
         handler.api = mock.MagicMock()
@@ -493,7 +546,7 @@ class TestModeSwitch:
 
     def test_switch_checkmode(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest", checkmode=True,
         )
         handler.api = mock.MagicMock()
@@ -519,7 +572,7 @@ class TestModeSwitch:
         mock_time.sleep = mock.MagicMock()
 
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest", wait=60, update_interval=5,
         )
         handler.api = mock.MagicMock()
@@ -565,7 +618,7 @@ class TestModeSwitch:
 
     def test_no_switch_when_opposite_deactivated(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest",
         )
         handler.api = mock.MagicMock()
@@ -582,7 +635,7 @@ class TestModeSwitch:
 
     def test_no_switch_when_opposite_not_in_features(self):
         handler = _make_handler(
-            ipxe_type="private", state="present",
+            state="private",
             ipxe_config="#!ipxe\ntest",
         )
         handler.api = mock.MagicMock()
@@ -604,7 +657,7 @@ class TestWait:
         mock_time.sleep = mock.MagicMock()
 
         handler = _make_handler(
-            state="present", wait=60, update_interval=5,
+            state="public", wait=60, update_interval=5,
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         handler.api = mock.MagicMock()
@@ -628,8 +681,14 @@ class TestWait:
         handler = _make_handler(state="absent", wait=60, update_interval=5)
         handler.api = mock.MagicMock()
         handler.api.get_dedicated_server_features.side_effect = [
-            [_make_feature("public_ipxe_boot", "activated")],
+            # initial call in _ensure_absent
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # wait poll: deactivating
             [_make_feature("public_ipxe_boot", "deactivation")],
+            # wait poll: done
             [_make_feature("public_ipxe_boot", "deactivated")],
         ]
 
@@ -645,7 +704,7 @@ class TestWait:
         mock_time.sleep = mock.MagicMock()
 
         handler = _make_handler(
-            state="present", wait=600, update_interval=10,
+            state="public", wait=600, update_interval=10,
             ipxe_config="#!ipxe\nchain http://boot.example.com",
         )
         handler.api = mock.MagicMock()

--- a/ansible_collections/serverscom/sc_api/tests/unit/plugins/modules/test_dedicated_server_ipxe.py
+++ b/ansible_collections/serverscom/sc_api/tests/unit/plugins/modules/test_dedicated_server_ipxe.py
@@ -1,0 +1,662 @@
+# Copyright (c) 2026 Servers.com
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+import pytest
+import mock
+from ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server import (
+    ScDedicatedServerIpxe,
+)
+from ansible_collections.serverscom.sc_api.plugins.module_utils.modules import (
+    WaitError,
+)
+
+
+__metaclass__ = type
+
+ENDPOINT = "https://api.servers.com/v1"
+TOKEN = "test-token"
+SERVER_ID = "srv123"
+
+
+def _make_feature(name, status, ipxe_config=None):
+    f = {"name": name, "status": status}
+    if ipxe_config is not None:
+        f["ipxe_config"] = ipxe_config
+    return f
+
+
+def _make_handler(ipxe_type="public", state="present", ipxe_config=None,
+                  wait=0, update_interval=10, checkmode=False):
+    return ScDedicatedServerIpxe(
+        endpoint=ENDPOINT,
+        token=TOKEN,
+        server_id=SERVER_ID,
+        ipxe_type=ipxe_type,
+        state=state,
+        ipxe_config=ipxe_config,
+        wait=wait,
+        update_interval=update_interval,
+        checkmode=checkmode,
+    )
+
+
+class TestActivate:
+    def test_activate_public_ipxe(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        features = [
+            _make_feature("public_ipxe_boot", "deactivated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.post_dedicated_server_feature_activate.return_value = (
+            _make_feature("public_ipxe_boot", "activation")
+        )
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot",
+            body={"ipxe_config": "#!ipxe\nchain http://boot.example.com"},
+        )
+
+    def test_activate_private_ipxe(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        features = [
+            _make_feature("public_ipxe_boot", "deactivated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.post_dedicated_server_feature_activate.return_value = (
+            _make_feature("private_ipxe_boot", "activation")
+        )
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "private_ipxe_boot",
+            body={"ipxe_config": "#!ipxe\nchain http://boot.example.com"},
+        )
+
+    def test_activate_with_ipxe_config(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com"
+        )
+        features = [_make_feature("public_ipxe_boot", "deactivated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot",
+            body={"ipxe_config": "#!ipxe\nchain http://boot.example.com"},
+        )
+
+    def test_activate_already_active_same_config(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="existing-config",
+        )
+        features = [
+            _make_feature("public_ipxe_boot", "activated", ipxe_config="existing-config")
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.get_dedicated_servers.return_value = {"ipxe_config": "existing-config"}
+
+        result = handler.run()
+
+        assert result["changed"] is False
+        handler.api.put_dedicated_server.assert_not_called()
+
+    def test_activate_already_active_with_config_update(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nnew-config"
+        )
+        features = [
+            _make_feature("public_ipxe_boot", "activated", ipxe_config="old-config")
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.get_dedicated_servers.return_value = {"ipxe_config": "old-config"}
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.put_dedicated_server.assert_called_once_with(
+            SERVER_ID, {"ipxe_config": "#!ipxe\nnew-config"}
+        )
+        handler.api.post_dedicated_server_feature_activate.assert_not_called()
+
+    def test_activate_already_active_config_unchanged(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="same-config"
+        )
+        features = [
+            _make_feature("public_ipxe_boot", "activated", ipxe_config="same-config")
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.get_dedicated_servers.return_value = {"ipxe_config": "same-config"}
+
+        result = handler.run()
+
+        assert result["changed"] is False
+        handler.api.put_dedicated_server.assert_not_called()
+
+    def test_activate_from_incompatible(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        features = [_make_feature("public_ipxe_boot", "incompatible")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_activate.assert_called_once()
+
+    def test_activate_from_unavailable(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        features = [_make_feature("public_ipxe_boot", "unavailable")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_activate.assert_called_once()
+
+    def test_activate_already_in_activation(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+            wait=0,
+        )
+        features = [_make_feature("public_ipxe_boot", "activation")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is False
+        handler.api.post_dedicated_server_feature_activate.assert_not_called()
+
+
+class TestDeactivate:
+    def test_deactivate_ipxe(self):
+        handler = _make_handler(state="absent")
+        features = [_make_feature("public_ipxe_boot", "activated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot"
+        )
+
+    def test_deactivate_already_inactive(self):
+        handler = _make_handler(state="absent")
+        features = [_make_feature("public_ipxe_boot", "deactivated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is False
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+
+    def test_deactivate_already_in_deactivation(self):
+        handler = _make_handler(state="absent", wait=0)
+        features = [_make_feature("public_ipxe_boot", "deactivation")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is False
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+
+    def test_deactivate_incompatible(self):
+        handler = _make_handler(state="absent")
+        features = [_make_feature("public_ipxe_boot", "incompatible")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is False
+
+    def test_deactivate_unavailable(self):
+        handler = _make_handler(state="absent")
+        features = [_make_feature("public_ipxe_boot", "unavailable")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is False
+
+
+class TestCheckMode:
+    def test_activate_checkmode(self):
+        handler = _make_handler(
+            state="present", checkmode=True,
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        features = [_make_feature("public_ipxe_boot", "deactivated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_activate.assert_not_called()
+
+    def test_activate_checkmode_already_active_same_config(self):
+        """In check mode with matching ipxe_config, changed=False."""
+        handler = _make_handler(
+            state="present", checkmode=True,
+            ipxe_config="existing-config",
+        )
+        features = [
+            _make_feature("public_ipxe_boot", "activated", ipxe_config="existing-config")
+        ]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.get_dedicated_servers.return_value = {"ipxe_config": "existing-config"}
+
+        result = handler.run()
+
+        assert result["changed"] is False
+        handler.api.put_dedicated_server.assert_not_called()
+
+    def test_activate_checkmode_with_different_config(self):
+        handler = _make_handler(
+            state="present", checkmode=True, ipxe_config="new"
+        )
+        features = [_make_feature("public_ipxe_boot", "activated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+        handler.api.get_dedicated_servers.return_value = {"ipxe_config": "old"}
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.put_dedicated_server.assert_not_called()
+
+    def test_deactivate_checkmode(self):
+        handler = _make_handler(state="absent", checkmode=True)
+        features = [_make_feature("public_ipxe_boot", "activated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+
+    def test_deactivate_checkmode_already_inactive(self):
+        handler = _make_handler(state="absent", checkmode=True)
+        features = [_make_feature("public_ipxe_boot", "deactivated")]
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = features
+
+        result = handler.run()
+
+        assert result["changed"] is False
+
+
+class TestModeSwitch:
+    def test_switch_public_to_private(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            # _get_feature_status: private deactivated
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # _get_opposite_feature_status: public activated
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot"
+        )
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "private_ipxe_boot",
+            body={"ipxe_config": "#!ipxe\nchain http://boot.example.com"},
+        )
+
+    def test_switch_private_to_public(self):
+        handler = _make_handler(
+            ipxe_type="public", state="present",
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            # _get_feature_status: public deactivated
+            [
+                _make_feature("public_ipxe_boot", "deactivated"),
+                _make_feature("private_ipxe_boot", "activated"),
+            ],
+            # _get_opposite_feature_status: private activated
+            [
+                _make_feature("public_ipxe_boot", "deactivated"),
+                _make_feature("private_ipxe_boot", "activated"),
+            ],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "private_ipxe_boot"
+        )
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot",
+            body={"ipxe_config": "#!ipxe\nchain http://boot.example.com"},
+        )
+
+    @mock.patch("ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server.time")
+    def test_switch_opposite_in_deactivation(self, mock_time):
+        mock_time.time.side_effect = [
+            # wait_for_status("deactivated") for opposite
+            0, 0, 5, 5, 10,
+            # wait_for_status("activated") for private
+            10, 10, 15,
+        ]
+        mock_time.sleep = mock.MagicMock()
+
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest", wait=60, update_interval=5,
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            # _get_feature_status: private deactivated
+            [
+                _make_feature("public_ipxe_boot", "deactivation"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # _get_opposite_feature_status: public in deactivation
+            [
+                _make_feature("public_ipxe_boot", "deactivation"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # wait_for_status poll for public: still deactivating
+            [
+                _make_feature("public_ipxe_boot", "deactivation"),
+            ],
+            # wait_for_status poll for public: done
+            [
+                _make_feature("public_ipxe_boot", "deactivated"),
+            ],
+            # wait_for_status poll for private: activated
+            [
+                _make_feature("private_ipxe_boot", "activated"),
+            ],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        assert result["feature"]["status"] == "activated"
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "private_ipxe_boot", body={"ipxe_config": "#!ipxe\ntest"},
+        )
+
+    def test_switch_opposite_in_deactivation_no_wait(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest", wait=0,
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            [
+                _make_feature("public_ipxe_boot", "deactivation"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # _get_feature_status re-fetch
+            [
+                _make_feature("public_ipxe_boot", "deactivation"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+        handler.api.post_dedicated_server_feature_activate.assert_called_once()
+
+    def test_switch_with_wait_zero(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest", wait=0,
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            # _get_feature_status: private deactivated
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # _get_opposite_feature_status: public activated
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot"
+        )
+        handler.api.post_dedicated_server_feature_activate.assert_called_once()
+
+    def test_switch_checkmode(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest", checkmode=True,
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = [
+            _make_feature("public_ipxe_boot", "activated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+        handler.api.post_dedicated_server_feature_activate.assert_not_called()
+
+    @mock.patch("ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server.time")
+    def test_switch_with_wait_full_cycle(self, mock_time):
+        mock_time.time.side_effect = [
+            # _deactivate_opposite wait_for_status: start, elapsed, sleep, elapsed
+            0, 0, 5, 5, 10,
+            # _ensure_present wait_for_status: start, elapsed, sleep, elapsed
+            10, 10, 15, 15, 20,
+        ]
+        mock_time.sleep = mock.MagicMock()
+
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest", wait=60, update_interval=5,
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            # _get_feature_status: private deactivated
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # _get_opposite_feature_status: public activated
+            [
+                _make_feature("public_ipxe_boot", "activated"),
+                _make_feature("private_ipxe_boot", "deactivated"),
+            ],
+            # wait for public deactivation: still deactivating
+            [
+                _make_feature("public_ipxe_boot", "deactivation"),
+            ],
+            # wait for public deactivation: done
+            [
+                _make_feature("public_ipxe_boot", "deactivated"),
+            ],
+            # wait for private activation: still activating
+            [
+                _make_feature("private_ipxe_boot", "activation"),
+            ],
+            # wait for private activation: done
+            [
+                _make_feature("private_ipxe_boot", "activated"),
+            ],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        assert result["feature"]["status"] == "activated"
+        handler.api.post_dedicated_server_feature_deactivate.assert_called_once_with(
+            SERVER_ID, "public_ipxe_boot"
+        )
+        handler.api.post_dedicated_server_feature_activate.assert_called_once_with(
+            SERVER_ID, "private_ipxe_boot", body={"ipxe_config": "#!ipxe\ntest"},
+        )
+
+    def test_no_switch_when_opposite_deactivated(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest",
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = [
+            _make_feature("public_ipxe_boot", "deactivated"),
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+        handler.api.post_dedicated_server_feature_activate.assert_called_once()
+
+    def test_no_switch_when_opposite_not_in_features(self):
+        handler = _make_handler(
+            ipxe_type="private", state="present",
+            ipxe_config="#!ipxe\ntest",
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.return_value = [
+            _make_feature("private_ipxe_boot", "deactivated"),
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        handler.api.post_dedicated_server_feature_deactivate.assert_not_called()
+        handler.api.post_dedicated_server_feature_activate.assert_called_once()
+
+
+class TestWait:
+    @mock.patch("ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server.time")
+    def test_wait_for_activation(self, mock_time):
+        mock_time.time.side_effect = [0, 0, 5, 5, 10]
+        mock_time.sleep = mock.MagicMock()
+
+        handler = _make_handler(
+            state="present", wait=60, update_interval=5,
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            [_make_feature("public_ipxe_boot", "deactivated")],
+            [_make_feature("public_ipxe_boot", "activation")],
+            [_make_feature("public_ipxe_boot", "activated")],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        assert result["feature"]["status"] == "activated"
+        assert handler.api.post_dedicated_server_feature_activate.call_count == 1
+
+    @mock.patch("ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server.time")
+    def test_wait_for_deactivation(self, mock_time):
+        mock_time.time.side_effect = [0, 0, 5, 5, 10]
+        mock_time.sleep = mock.MagicMock()
+
+        handler = _make_handler(state="absent", wait=60, update_interval=5)
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            [_make_feature("public_ipxe_boot", "activated")],
+            [_make_feature("public_ipxe_boot", "deactivation")],
+            [_make_feature("public_ipxe_boot", "deactivated")],
+        ]
+
+        result = handler.run()
+
+        assert result["changed"] is True
+        assert result["feature"]["status"] == "deactivated"
+
+    @mock.patch("ansible_collections.serverscom.sc_api.plugins.module_utils.dedicated_server.time")
+    def test_wait_timeout(self, mock_time):
+        # time.time() calls: start=0, loop1_check=1, loop1_retry=2, loop2_check=601
+        mock_time.time.side_effect = [0, 1, 2, 601]
+        mock_time.sleep = mock.MagicMock()
+
+        handler = _make_handler(
+            state="present", wait=600, update_interval=10,
+            ipxe_config="#!ipxe\nchain http://boot.example.com",
+        )
+        handler.api = mock.MagicMock()
+        handler.api.get_dedicated_server_features.side_effect = [
+            # _get_feature_status
+            [_make_feature("public_ipxe_boot", "deactivated")],
+            # _get_opposite_feature_status (no opposite found)
+            [_make_feature("public_ipxe_boot", "deactivated")],
+            # wait poll: still activating
+            [_make_feature("public_ipxe_boot", "activation")],
+        ]
+
+        with pytest.raises(WaitError):
+            handler.run()


### PR DESCRIPTION
Implements a new Ansible module for managing iPXE boot configuration on dedicated servers. Supports public/private iPXE modes with automatic deactivation of the opposite feature. Includes unit tests, integration tests, and API layer extensions.