### PR TITLE
Update os

### DIFF
--- a/ansible_collections/serverscom/sc_api/plugins/modules/load_balancer_instance_info.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/load_balancer_instance_info.py
@@ -176,7 +176,7 @@ vhost_zones:
       type: bool
       sample: false
     http2:
-      description: Indicates if HTTP/2 protocol is enabled. (L7 only)
+      description: Indicates if HTTP/2 protocol is enabled. Temporarily unavailable. (L7 only)
       type: bool
       sample: false
     http_to_https_redirect:
@@ -184,7 +184,7 @@ vhost_zones:
       type: bool
       sample: false
     http2_push_preload:
-      description: Indicates HTTP/2 push preload status. (L7 only)
+      description: Indicates HTTP/2 push preload status. Temporarily unavailable. (L7 only)
       type: bool
       sample: false
     domains:

--- a/ansible_collections/serverscom/sc_api/plugins/modules/load_balancer_instance_l7.py
+++ b/ansible_collections/serverscom/sc_api/plugins/modules/load_balancer_instance_l7.py
@@ -74,7 +74,7 @@ options:
         type: bool
         default: false
       http2:
-        description: Enable HTTP/2 protocol.
+        description: Enable HTTP/2 protocol. Temporarily unavailable.
         type: bool
         default: false
       http_to_https_redirect:
@@ -82,7 +82,7 @@ options:
         type: bool
         default: false
       http2_push_preload:
-        description: Enable HTTP/2 push preload.
+        description: Enable HTTP/2 push preload. Temporarily unavailable.
         type: bool
         default: false
       domains:
@@ -314,7 +314,7 @@ vhost_zones:
       returned: always
       type: bool
     http2:
-      description: "Indicates if HTTP/2 is enabled."
+      description: "Indicates if HTTP/2 is enabled. Temporarily unavailable."
       returned: always
       type: bool
     http_to_https_redirect:
@@ -322,7 +322,7 @@ vhost_zones:
       returned: always
       type: bool
     http2_push_preload:
-      description: "Indicates if HTTP/2 push preload is enabled."
+      description: "Indicates if HTTP/2 push preload is enabled. Temporarily unavailable."
       returned: always
       type: bool
     domains:
@@ -475,9 +475,7 @@ EXAMPLES = """
       - id: "zone1"
         ports: [80, 443]
         ssl: true
-        http2: true
         http_to_https_redirect: false
-        http2_push_preload: false
         domains: ["example.com", "www.example.com"]
         ssl_certificate_id: "cert-12345"
         location_zones:

--- a/ansible_collections/serverscom/sc_api/tests/integration/README.md
+++ b/ansible_collections/serverscom/sc_api/tests/integration/README.md
@@ -34,21 +34,31 @@ Update these to match your account's available resources.
 
 **Cloud Computing:**
 `cloud_test_region_id`, `cloud_test_flavor_id`, `cloud_test_flavor_name`,
-`cloud_test_ssh_key_fingerprint`, `cloud_test_region_search_pattern`,
-`cloud_test_region_search_match`, `cloud_test_region_search_nomatch`
+`cloud_test_ssh_key_fingerprint`, `cloud_test_image_name`,
+`cloud_test_image_regex`, `cloud_test_reinstall_image_regex`,
+`cloud_test_rescue_image_regex`, `cloud_test_invalid_image_regex`,
+`cloud_test_region_search_pattern`, `cloud_test_region_search_match`,
+`cloud_test_region_search_nomatch`
 
 **Baremetal:**
 `baremetal_test_location_search_pattern`, `baremetal_test_location_search_match`,
 `baremetal_test_location_search_nomatch`, `baremetal_test_os_location_id`,
 `baremetal_test_os_location_code`, `baremetal_test_os_server_model_id`,
-`baremetal_test_os_server_model_name`
+`baremetal_test_os_server_model_name`, `baremetal_test_os_regex`,
+`baremetal_test_os_nomatch_regex`
 
 **Dedicated server reinstall:**
-`dedicated_test_reinstall_os_id`, `dedicated_test_reinstall_ssh_key_fingerprint`,
+`dedicated_test_reinstall_os_id`, `dedicated_test_reinstall_quick_os_id`,
+`dedicated_test_reinstall_os_regex`,
+`dedicated_test_reinstall_ambiguous_os_regex`,
+`dedicated_test_reinstall_missing_os_regex`,
+`dedicated_test_reinstall_ssh_key_fingerprint`,
 `dedicated_test_reinstall_ssh_key_name`
 
 **SBM (Scalable Baremetal):**
-`sbm_test_location_code`, `sbm_test_flavor_name`, `sbm_test_os_regex`,
-`sbm_test_reinstall_os_name`
+`sbm_test_location_code`, `sbm_test_flavor_name`, `sbm_test_create_os_name`,
+`sbm_test_os_regex`, `sbm_test_os_filter_default`,
+`sbm_test_reinstall_quick_os_id`, `sbm_test_reinstall_os_name`,
+`sbm_test_invalid_os_name`, `sbm_test_invalid_os_regex`
 
 See the Justfile recipes (in the root directory of this project) for local development.

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/baremetal_os_list/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/baremetal_os_list/tasks/main.yaml
@@ -28,7 +28,7 @@
 - name: Test2, Get OS list by name regex
   sc_baremetal_os_list:
     server_id: "{{ existing_server1_id }}"
-    os_name_regex: "^Ubuntu 24.04-server x86_64$"
+    os_name_regex: "{{ baremetal_test_os_regex }}"
   environment:
     SERVERSCOM_API_TOKEN: '{{ sc_token }}'
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -76,7 +76,7 @@
 - name: Test5, None OS options found
   sc_baremetal_os_list:
     server_id: "{{ existing_server1_id }}"
-    os_name_regex: "^Ubuntu 24.04-server arm64$"
+    os_name_regex: "{{ baremetal_test_os_nomatch_regex }}"
   environment:
     SERVERSCOM_API_TOKEN: '{{ sc_token }}'
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance/tasks/main.yaml
@@ -74,6 +74,11 @@
   register: flavor_info
   tags: always
 
+- name: Tests prep, store image id
+  set_fact:
+    cloud_test_image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+  tags: always
+
 - name: Test5, create instance new in check_mode
   tags: [test5]
   block:
@@ -82,7 +87,7 @@
         state: present
         region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+        image_id: "{{ cloud_test_image_id }}"
         name: ec354674-e844-11ea-ac53-83e1244f3049
         backup_copies: 0
         gpn: true
@@ -126,7 +131,7 @@
         state: present
         region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+        image_id: "{{ cloud_test_image_id }}"
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
         gpn: true
@@ -159,7 +164,7 @@
         state: present
         region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+        image_id: "{{ cloud_test_image_id }}"
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
         gpn: true
@@ -176,7 +181,7 @@
         state: present
         region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+        image_id: "{{ cloud_test_image_id }}"
         name: 52310c60-7446-482d-a30e-2bedeb515878
         backup_copies: 0
         gpn: true
@@ -217,7 +222,7 @@
         state: present
         region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+        image_id: "{{ cloud_test_image_id }}"
         name: c4edd55c-8a79-4181-b880-917b8ee5cdf2
         backup_copies: 0
         gpn: false
@@ -325,7 +330,7 @@
         name: 15a0688b-44f6-41e2-971c-4e860c402373
         region_id: "{{ regions.regions[0].id }}"
         flavor_name: "dont.exist"
-        image_id: "{{ (img_info.cloud_images | selectattr('allowed_flavors', 'equalto', []) | first).id }}"
+        image_id: "{{ cloud_test_image_id }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -338,7 +343,7 @@
         name: 15a0688b-44f6-41e2-971c-4e860c402373
         region_id: "{{ regions.regions[0].id }}"
         flavor_id: '{{ (flavor_info.cloud_flavors|sort(attribute="disk"))[0].id }}'
-        image_regexp: a.+dont.exist
+        image_regexp: "{{ cloud_test_invalid_image_regex }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -349,7 +354,7 @@
       assert:
         that:
           - "'Unable to find flavor by name dont.exist' in test8_flavor.msg"
-          - "'Unable to find image by regexp a.+dont.exist' in test8_image.msg"
+          - "('Unable to find image by regexp ' ~ cloud_test_invalid_image_regex) in test8_image.msg"
 
   always:
     - name: Test8, cleanup
@@ -369,7 +374,7 @@
         name: 8d2779e6-eb72-11ea-970f-733ca983e4ca
         region_id: "{{ regions.regions[0].id }}"
         flavor_name: "{{ cloud_test_flavor_name }}"
-        image_regexp: "Ubuntu.+"
+        image_regexp: "{{ cloud_test_image_regex }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -422,7 +427,7 @@
         gpn: true
         ipv4: false
         flavor_name: "{{ cloud_test_flavor_name }}"
-        image_regexp: "Ubuntu.+"
+        image_regexp: "{{ cloud_test_image_regex }}"
         ssh_key_name: 95f41cea-00fc-11ed-bfa8-33691f518c37
         user_data: |
           #cloud-config

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_info/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_info/tasks/main.yaml
@@ -21,7 +21,7 @@
       - "'v1/cloud_computing/instances/M7e5Ba2v' in test1.api_url"
       - test1.status_code != 200
 
-- name: Get Debian 12 image ID
+- name: Get configured image ID
   sc_cloud_computing_images_info:
     region_id: "{{ cloud_test_region_id }}"
   environment:
@@ -29,16 +29,16 @@
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'
   register: images_info
 
-- name: Store Debian 12 image ID
+- name: Store configured image ID
   set_fact:
-    debian_12_image_id: "{{ images_info.cloud_images | selectattr('name','equalto','Debian 12 (64 bit)') | map(attribute='id') | first }}"
+    cloud_test_named_image_id: "{{ images_info.cloud_images | selectattr('name','equalto', cloud_test_image_name) | map(attribute='id') | first }}"
 
 - name: Create test instance
   sc_cloud_computing_instance:
     state: present
     region_id: "{{ cloud_test_region_id }}"
     flavor_id: "{{ cloud_test_flavor_id }}"
-    image_id: "{{ debian_12_image_id }}"
+    image_id: "{{ cloud_test_named_image_id }}"
     name: "sc-cloud-computing-instance-info-test"
     ssh_key_fingerprint: "{{ cloud_test_ssh_key_fingerprint }}"
     labels:
@@ -68,7 +68,7 @@
       - test2.status == "ACTIVE"
       - test2.region_id == cloud_test_region_id
       - test2.flavor_id == cloud_test_flavor_id
-      - test2.image_id == debian_12_image_id
+      - test2.image_id == cloud_test_named_image_id
       - test2.labels.test_label == "test_value"
       - test2.backup_copies == 0
       - test2.gpn_enabled == true

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_ptr/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_ptr/tasks/main.yaml
@@ -19,7 +19,7 @@
         state: present
         region_id: "{{ regions.regions[0].id }}"
         flavor_name: "{{ cloud_test_flavor_name }}"
-        image_regexp: "Ubuntu.+"
+        image_regexp: "{{ cloud_test_image_regex }}"
         name: 537eb44e-eced-11ea-8fef-3b4e87dd916a
         backup_copies: 0
         gpn: true

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_reinstall/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_reinstall/tasks/main.yaml
@@ -19,7 +19,7 @@
         state: present
         region_id: '{{ regions.regions[0].id }}'
         flavor_name: "{{ cloud_test_flavor_name }}"
-        image_regexp: 'Ubuntu.+'
+        image_regexp: "{{ cloud_test_image_regex }}"
         name: '{{ instance_name }}'
         backup_copies: 0
         gpn: true
@@ -63,7 +63,7 @@
       sc_cloud_computing_instance:
         state: reinstalled
         instance_id: '{{ instance.id }}'
-        image_regexp: 'Debian.+'
+        image_regexp: "{{ cloud_test_reinstall_image_regex }}"
         wait: 600
         update_interval: 5
       environment:

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_state/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instance_state/tasks/main.yaml
@@ -18,7 +18,7 @@
         state: present
         region_id: '{{ regions.regions[0].id }}'
         flavor_name: "{{ cloud_test_flavor_name }}"
-        image_regexp: 'Ubuntu.+'
+        image_regexp: "{{ cloud_test_image_regex }}"
         name: 4839550e-edf5-11ea-8df4-4f25b3878e42
         backup_copies: 0
         gpn: true
@@ -260,7 +260,7 @@
     - name: Test11, rescue with image_regexp
       sc_cloud_computing_instance_state:
         name: 4839550e-edf5-11ea-8df4-4f25b3878e42
-        image_regexp: '.*Cent.+'
+        image_regexp: "{{ cloud_test_rescue_image_regex }}"
         state: '{{ item }}'
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instances_info/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/cloud_computing_instances_info/tasks/main.yaml
@@ -54,7 +54,7 @@
       - test3 is not changed
       - test3.cloud_instances|length > 0
 
-- name: Get Debian 12 image ID
+- name: Get configured image ID
   sc_cloud_computing_images_info:
     region_id: "{{ cloud_test_region_id }}"
   environment:
@@ -62,16 +62,16 @@
     SERVERSCOM_API_URL: '{{ sc_endpoint }}'
   register: images_info
 
-- name: Store Debian 12 image ID
+- name: Store configured image ID
   set_fact:
-    debian_12_image_id: "{{ images_info.cloud_images | selectattr('name','equalto','Debian 12 (64 bit)') | map(attribute='id') | first }}"
+    cloud_test_named_image_id: "{{ images_info.cloud_images | selectattr('name','equalto', cloud_test_image_name) | map(attribute='id') | first }}"
 
 - name: Create test instance with labels
   sc_cloud_computing_instance:
     state: present
     region_id: "{{ cloud_test_region_id }}"
     flavor_id: "{{ cloud_test_flavor_id }}"
-    image_id: "{{ debian_12_image_id }}"
+    image_id: "{{ cloud_test_named_image_id }}"
     name: "sc-cloud-computing-instances-info-test"
     ssh_key_fingerprint: "{{ cloud_test_ssh_key_fingerprint }}"
     labels:

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_1/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_1/tasks/main.yaml
@@ -42,7 +42,7 @@
   sc_dedicated_server_reinstall:
     id: '{{ existing_server1_id }}'
     drives_layout_template: raid0-simple
-    operating_system_regex: "^debian (.*)x86_64$"
+    operating_system_regex: "{{ dedicated_test_reinstall_ambiguous_os_regex }}"
     hostname: raid0test
     ssh_key_name: "{{ dedicated_test_reinstall_ssh_key_name }}"
     wait: 3600
@@ -58,15 +58,14 @@
   assert:
     that:
       - test4 is not changed
-      - >-
-        test4.msg is match("(?s)^Multiple OS options match the
-        regex '\\^debian \\(.*\\)x86_64\\$': .*")
+      - test4.msg is match("(?s)^Multiple OS options match the regex")
+      - dedicated_test_reinstall_ambiguous_os_regex in test4.msg
 
 - name: Test5, reinstall with raid0_template and non-existing OS regex
   sc_dedicated_server_reinstall:
     id: '{{ existing_server1_id }}'
     drives_layout_template: raid0-simple
-    operating_system_regex: "^Debian 6(.*)x86_64$"
+    operating_system_regex: "{{ dedicated_test_reinstall_missing_os_regex }}"
     hostname: raid0test
     ssh_key_name: "{{ dedicated_test_reinstall_ssh_key_name }}"
     wait: 3600
@@ -82,7 +81,5 @@
   assert:
     that:
       - test5 is not changed
-      - >-
-        test5.msg is match("(?s)^No OS options match the regex
-        '\\^Debian 6\\(.*\\)x86_64\\$' for server model 'Supermicro X11DPL-i /
-        2 x Intel Xeon Silver 4114 / 32 GB RAM / 1 x 480 GB SSD' in location 'WAS1'.*")
+      - test5.msg is match("(?s)^No OS options match the regex")
+      - dedicated_test_reinstall_missing_os_regex in test5.msg

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_noraid/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_noraid/tasks/main.yaml
@@ -21,7 +21,7 @@
   sc_dedicated_server_reinstall:
     id: '{{ existing_server3_id }}'
     drives_layout_template: no-raid
-    operating_system_regex: "^Debian 12 (.*)x86_64$"
+    operating_system_regex: "{{ dedicated_test_reinstall_os_regex }}"
     hostname: noraidtest
     ssh_key_name: "{{ dedicated_test_reinstall_ssh_key_name }}"
     wait: 3600

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_quick/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_quick/tasks/main.yaml
@@ -30,7 +30,7 @@
     id: '{{ existing_server1_id }}'
     drives_layout_template: raid1-simple
     ssh_key_name: should-not-exists
-    operating_system_id: '42'
+    operating_system_id: "{{ dedicated_test_reinstall_quick_os_id }}"
     hostname: somename
   environment:
     SERVERSCOM_API_TOKEN: '{{ sc_token }}'
@@ -50,7 +50,7 @@
     drives_layout_template: raid1-simple
     ssh_keys:
       - '58:e5:58:e9:38:10:82:57:d9:82:11:8c:f6:44:68:e8'
-    operating_system_id: '42'
+    operating_system_id: "{{ dedicated_test_reinstall_quick_os_id }}"
     hostname: somename
   environment:
     SERVERSCOM_API_TOKEN: '{{ sc_token }}'

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_raid0/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/dedicated_server_reinstall_raid0/tasks/main.yaml
@@ -21,7 +21,7 @@
   sc_dedicated_server_reinstall:
     id: '{{ existing_server2_id }}'
     drives_layout_template: raid0-simple
-    operating_system_regex: "^Debian 12 (.*)x86_64$"
+    operating_system_regex: "{{ dedicated_test_reinstall_os_regex }}"
     hostname: raid0test
     ssh_key_name: "{{ dedicated_test_reinstall_ssh_key_name }}"
     wait: 3600

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/load_balancer_instance_info/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/load_balancer_instance_info/tasks/main.yaml
@@ -56,9 +56,10 @@
           - id: "zone1"
             ports: [80]
             ssl: false
-            http2: true
+            # HTTP/2 is disabled in the API.
+            # http2: true
             http_to_https_redirect: false
-            http2_push_preload: false
+            # http2_push_preload: false
             domains: ["demo.test"]
             location_zones:
               - location: "/"

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/load_balancer_instance_l7/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/load_balancer_instance_l7/tasks/main.yaml
@@ -18,9 +18,10 @@
           - id: "zone1"
             ports: [80]
             ssl: false
-            http2: true
+            # HTTP/2 is disabled in the API.
+            # http2: true
             http_to_https_redirect: false
-            http2_push_preload: false
+            # http2_push_preload: false
             domains: ["demo.test"]
             location_zones:
               - location: "/"
@@ -89,7 +90,8 @@
           - (test2.vhost_zones | length) == 1
           - (test2.vhost_zones[0].domains | length) == 1
           - test2.vhost_zones[0].domains[0] == "demo.test"
-          - test2.vhost_zones[0].http2 == true
+          # HTTP/2 is disabled in the API.
+          # - test2.vhost_zones[0].http2 == true
           - test2.vhost_zones[0].id == "zone1"
           - (test2.vhost_zones[0].location_zones | length) == 1
           - test2.vhost_zones[0].location_zones[0].location == "/"
@@ -162,9 +164,10 @@
           - id: "zone1"
             ports: [80]
             ssl: false
-            http2: true
+            # HTTP/2 is disabled in the API.
+            # http2: true
             http_to_https_redirect: false
-            http2_push_preload: false
+            # http2_push_preload: false
             domains: ["demo.test"]
             location_zones:
               - location: "/"
@@ -208,9 +211,10 @@
           - id: "zone1"
             ports: [80]
             ssl: false
-            http2: true
+            # HTTP/2 is disabled in the API.
+            # http2: true
             http_to_https_redirect: false
-            http2_push_preload: false
+            # http2_push_preload: false
             domains: ["demo.test"]
             location_zones:
               - location: "/"

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sbm_os_list/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sbm_os_list/tasks/main.yaml
@@ -60,7 +60,7 @@
       serverscom.sc_api.sc_sbm_os_list:
         location_id: "{{ locations.locations[0].id }}"
         flavor_id: "{{ flavors.sbm_flavor_models[0].id }}"
-        os_name_regex: "{{ test1.os_list[0].full_name[:5] | default('Linux') }}"
+        os_name_regex: "{{ test1.os_list[0].full_name[:5] | default(sbm_test_os_filter_default) }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sbm_server_lifecycle/tasks/main.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sbm_server_lifecycle/tasks/main.yaml
@@ -44,7 +44,7 @@
         location_code: ZZZZZZ_INVALID
         flavor_name: "{{ sbm_test_flavor_name }}"
         hostname: ci-sbm-negative-test
-        operating_system_name: 'Debian 13 64-bit'
+        operating_system_name: "{{ sbm_test_create_os_name }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -63,7 +63,7 @@
         location_code: "{{ sbm_test_location_code }}"
         flavor_name: NONEXISTENT_FLAVOR_XYZ
         hostname: ci-sbm-negative-test
-        operating_system_name: 'Debian 13 64-bit'
+        operating_system_name: "{{ sbm_test_create_os_name }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'
@@ -82,7 +82,7 @@
         location_code: "{{ sbm_test_location_code }}"
         flavor_name: "{{ sbm_test_flavor_name }}"
         hostname: ci-sbm-negative-test
-        operating_system_name: 'NonexistentOS 99.99 64-bit'
+        operating_system_name: "{{ sbm_test_invalid_os_name }}"
       environment:
         SERVERSCOM_API_TOKEN: '{{ sc_token }}'
         SERVERSCOM_API_URL: '{{ sc_endpoint }}'

--- a/ansible_collections/serverscom/sc_api/tests/integration/targets/sbm_server_lifecycle/tasks/test_reinstall.yaml
+++ b/ansible_collections/serverscom/sc_api/tests/integration/targets/sbm_server_lifecycle/tasks/test_reinstall.yaml
@@ -23,7 +23,7 @@
   serverscom.sc_api.sc_sbm_server_reinstall:
     server_id: '{{ test_sbm_server_id }}'
     ssh_key_name: should-not-exists
-    operating_system_id: 42
+    operating_system_id: "{{ sbm_test_reinstall_quick_os_id }}"
     hostname: somename
   environment:
     SERVERSCOM_API_TOKEN: '{{ sc_token }}'
@@ -72,7 +72,7 @@
 - name: Test4, Error on no matching OS regex
   serverscom.sc_api.sc_sbm_server_reinstall:
     server_id: '{{ test_sbm_server_id }}'
-    operating_system_regex: 'NonExistentOS12345'
+    operating_system_regex: "{{ sbm_test_invalid_os_regex }}"
     hostname: test-server
     wait: 0
   environment:
@@ -124,7 +124,7 @@
       - test6 is changed
 
 # Test real reinstall with operating_system_name
-- name: Test7, Reinstall server to Ubuntu 24.04 using operating_system_name
+- name: Test7, Reinstall server using operating_system_name
   serverscom.sc_api.sc_sbm_server_reinstall:
     server_id: '{{ test_sbm_server_id }}'
     operating_system_name: "{{ sbm_test_reinstall_os_name }}"
@@ -166,7 +166,7 @@
 - name: Test9, Reinstall with nonexistent operating_system_name
   serverscom.sc_api.sc_sbm_server_reinstall:
     server_id: '{{ test_sbm_server_id }}'
-    operating_system_name: 'NonexistentOS 99.99 64-bit'
+    operating_system_name: "{{ sbm_test_invalid_os_name }}"
     hostname: '{{ test_hostname }}'
     wait: 0
   environment:

--- a/integration_config.yml.template
+++ b/integration_config.yml.template
@@ -23,7 +23,7 @@ cloud_test_region_id: 2
 cloud_test_flavor_id: "33227-1"
 cloud_test_flavor_name: SSD.30
 cloud_test_ssh_key_fingerprint: "9b:08:4d:a5:6d:45:26:72:2c:e0:9a:ee:bf:7d:03:a6"
-cloud_test_image_name: "Debian 12 (64 bit)"
+cloud_test_image_name: "Debian 13 (64 bit)"
 cloud_test_image_regex: "Ubuntu.+"
 cloud_test_reinstall_image_regex: "Debian.+"
 cloud_test_rescue_image_regex: ".*Cent.+"
@@ -44,8 +44,8 @@ baremetal_test_os_regex: "^Ubuntu 24.04-server x86_64$"
 baremetal_test_os_nomatch_regex: "^Ubuntu 24.04-server arm64$"
 
 # Dedicated server reinstall tests
-dedicated_test_reinstall_os_id: 49
-dedicated_test_reinstall_quick_os_id: 42
+dedicated_test_reinstall_os_id: 95
+dedicated_test_reinstall_quick_os_id: 100
 dedicated_test_reinstall_os_regex: "^Debian 12 (.*)x86_64$"
 dedicated_test_reinstall_ambiguous_os_regex: "^debian (.*)x86_64$"
 dedicated_test_reinstall_missing_os_regex: "^Debian 6(.*)x86_64$"
@@ -58,7 +58,7 @@ sbm_test_flavor_name: DL-01
 sbm_test_create_os_name: "Debian 13 64-bit"
 sbm_test_os_regex: "Debian 13"
 sbm_test_os_filter_default: Linux
-sbm_test_reinstall_quick_os_id: 42
+sbm_test_reinstall_quick_os_id: 95
 sbm_test_reinstall_os_name: "Ubuntu 24.04-server x86_64"
 sbm_test_invalid_os_name: "NonexistentOS 99.99 64-bit"
 sbm_test_invalid_os_regex: "NonExistentOS12345"

--- a/integration_config.yml.template
+++ b/integration_config.yml.template
@@ -23,6 +23,11 @@ cloud_test_region_id: 2
 cloud_test_flavor_id: "33227-1"
 cloud_test_flavor_name: SSD.30
 cloud_test_ssh_key_fingerprint: "9b:08:4d:a5:6d:45:26:72:2c:e0:9a:ee:bf:7d:03:a6"
+cloud_test_image_name: "Debian 12 (64 bit)"
+cloud_test_image_regex: "Ubuntu.+"
+cloud_test_reinstall_image_regex: "Debian.+"
+cloud_test_rescue_image_regex: ".*Cent.+"
+cloud_test_invalid_image_regex: "a.+dont.exist"
 cloud_test_region_search_pattern: WAS
 cloud_test_region_search_match: WAS1
 cloud_test_region_search_nomatch: AMS1
@@ -35,14 +40,25 @@ baremetal_test_os_location_id: 34
 baremetal_test_os_location_code: ams1
 baremetal_test_os_server_model_id: 11940
 baremetal_test_os_server_model_name: "Dell R730xd / 2xIntel Xeon E5-2680 v3 / 32 GB RAM / 4x600 GB SAS"
+baremetal_test_os_regex: "^Ubuntu 24.04-server x86_64$"
+baremetal_test_os_nomatch_regex: "^Ubuntu 24.04-server arm64$"
 
 # Dedicated server reinstall tests
 dedicated_test_reinstall_os_id: 49
+dedicated_test_reinstall_quick_os_id: 42
+dedicated_test_reinstall_os_regex: "^Debian 12 (.*)x86_64$"
+dedicated_test_reinstall_ambiguous_os_regex: "^debian (.*)x86_64$"
+dedicated_test_reinstall_missing_os_regex: "^Debian 6(.*)x86_64$"
 dedicated_test_reinstall_ssh_key_fingerprint: "f7:90:27:e6:97:5e:6d:ad:31:51:65:26:8d:82:ac:f9"
 dedicated_test_reinstall_ssh_key_name: amarao
 
 # SBM (Scalable Baremetal) tests
 sbm_test_location_code: AMS7
 sbm_test_flavor_name: DL-01
+sbm_test_create_os_name: "Debian 13 64-bit"
 sbm_test_os_regex: "Debian 13"
+sbm_test_os_filter_default: Linux
+sbm_test_reinstall_quick_os_id: 42
 sbm_test_reinstall_os_name: "Ubuntu 24.04-server x86_64"
+sbm_test_invalid_os_name: "NonexistentOS 99.99 64-bit"
+sbm_test_invalid_os_regex: "NonExistentOS12345"


### PR DESCRIPTION
1. Switch to newer Debian/Ubuntu in tests (old tests are failing on non-existing OSes).
2. Move all OS to variables (for integration tests)
3. Commented out http/2 in LB tests
4. Mark http/2 as temporary unavailable in module docs